### PR TITLE
fix: Recognize 2025-2026 Apple chips so models aren't flagged unsupported

### DIFF
--- a/Eris./Models/AIModels.swift
+++ b/Eris./Models/AIModels.swift
@@ -315,6 +315,14 @@ class AIModelsRegistry {
         let chipFamily = DeviceUtils.chipFamily
         let deviceRAM = DeviceUtils.estimatedRAM
 
+        // Safety net: hardware newer than our chip table resolves to .unknown.
+        // If the device supports Metal 3 it can run MLX, so don't blanket-block it —
+        // otherwise a brand-new top-tier device (e.g. a future iPhone) would show
+        // every model as "Not recommended - High crash risk".
+        if chipFamily == .unknown && DeviceUtils.canRunMLX {
+            return .compatible
+        }
+
         // Check if chip meets minimum requirement
         guard chipFamily.rawValue >= model.minimumChipRequired.rawValue else {
             return .notRecommended
@@ -405,9 +413,13 @@ extension DeviceUtils {
             return 8192  // 8GB
         case .a18, .a18Pro:
             return 8192  // 8GB
+        case .a19:
+            return 8192  // 8GB (iPhone 17)
+        case .a19Pro:
+            return 12288 // 12GB (iPhone 17 Pro/Pro Max, iPhone Air)
         case .m1, .m2:
             return 8192  // 8GB minimum
-        case .m3, .m4:
+        case .m3, .m4, .m5:
             return 16384 // 16GB minimum
         default:
             return 4096  // Conservative estimate

--- a/Eris./Models/LLMEvaluator.swift
+++ b/Eris./Models/LLMEvaluator.swift
@@ -156,10 +156,10 @@ class LLMEvaluator: ObservableObject {
         case .a15:
             // iPhone 13, 14 series - 6GB RAM devices
             baseCacheSize = 128
-        case .a16, .a17Pro, .a18, .a18Pro:
-            // iPhone 14 Pro, 15, 16 series - 6-8GB RAM devices
+        case .a16, .a17Pro, .a18, .a18Pro, .a19, .a19Pro:
+            // iPhone 14 Pro, 15, 16, 17 series - 6-12GB RAM devices
             baseCacheSize = 256
-        case .m1, .m2, .m3, .m4:
+        case .m1, .m2, .m3, .m4, .m5:
             // iPad with M chips - 8GB+ RAM
             baseCacheSize = 512
         default:

--- a/Eris./Utils/DeviceUtils.swift
+++ b/Eris./Utils/DeviceUtils.swift
@@ -27,10 +27,13 @@ struct DeviceUtils {
         case a17Pro = 6
         case a18 = 7
         case a18Pro = 8
-        case m1 = 9
-        case m2 = 10
-        case m3 = 11
-        case m4 = 12
+        case a19 = 9
+        case a19Pro = 10
+        case m1 = 11
+        case m2 = 12
+        case m3 = 13
+        case m4 = 14
+        case m5 = 15
     }
     
     static var isSimulator: Bool {
@@ -122,7 +125,20 @@ struct DeviceUtils {
         if model.contains("iphone17,3") || model.contains("iphone17,4") {
             return .a18Pro
         }
-        
+        // A18 - iPhone 16e
+        if model.contains("iphone17,5") {
+            return .a18
+        }
+        // A19 Pro - iPhone 17 Pro/Pro Max and iPhone Air
+        if model.contains("iphone18,1") || model.contains("iphone18,2") ||
+           model.contains("iphone18,4") {
+            return .a19Pro
+        }
+        // A19 - iPhone 17
+        if model.contains("iphone18,3") {
+            return .a19
+        }
+
         // iPad models with M-series chips
         if model.contains("ipad13,4") || model.contains("ipad13,5") ||
            model.contains("ipad13,6") || model.contains("ipad13,7") {
@@ -143,7 +159,16 @@ struct DeviceUtils {
            model.contains("ipad16,5") || model.contains("ipad16,6") {
             return .m4 // iPad Pro M4
         }
-        
+        if model.contains("ipad16,1") || model.contains("ipad16,2") {
+            return .a17Pro // iPad mini (A17 Pro)
+        }
+        if model.contains("ipad15,3") || model.contains("ipad15,4") {
+            return .m3 // iPad Air M3
+        }
+        if model.contains("ipad17,1") || model.contains("ipad17,2") {
+            return .m5 // iPad Pro M5
+        }
+
         // Mac detection (when running as Designed for iPad)
         #if os(iOS) && arch(arm64)
         if ProcessInfo.processInfo.isiOSAppOnMac {
@@ -157,6 +182,8 @@ struct DeviceUtils {
                 return .m3
             } else if cpuType.contains("Apple M4") {
                 return .m4
+            } else if cpuType.contains("Apple M5") {
+                return .m5
             }
             return .m1 // Default to M1 if can't detect specific version
         }
@@ -272,7 +299,22 @@ struct DeviceUtils {
         if model.contains("iphone17,4") {
             return "iPhone 16 Pro Max"
         }
-        
+        if model.contains("iphone17,5") {
+            return "iPhone 16e"
+        }
+        if model.contains("iphone18,1") {
+            return "iPhone 17 Pro"
+        }
+        if model.contains("iphone18,2") {
+            return "iPhone 17 Pro Max"
+        }
+        if model.contains("iphone18,3") {
+            return "iPhone 17"
+        }
+        if model.contains("iphone18,4") {
+            return "iPhone Air"
+        }
+
         // iPad models mapping
         if model.contains("ipad13,4") || model.contains("ipad13,5") ||
            model.contains("ipad13,6") || model.contains("ipad13,7") {
@@ -293,7 +335,16 @@ struct DeviceUtils {
            model.contains("ipad16,5") || model.contains("ipad16,6") {
             return "iPad Pro (M4)"
         }
-        
+        if model.contains("ipad16,1") || model.contains("ipad16,2") {
+            return "iPad mini (A17 Pro)"
+        }
+        if model.contains("ipad15,3") || model.contains("ipad15,4") {
+            return "iPad Air (M3)"
+        }
+        if model.contains("ipad17,1") || model.contains("ipad17,2") {
+            return "iPad Pro (M5)"
+        }
+
         // Simulator
         if isSimulator {
             return "Simulator"
@@ -337,6 +388,10 @@ struct DeviceUtils {
                     return "A18 (Metal 3)"
                 case .a18Pro:
                     return "A18 Pro (Metal 3)"
+                case .a19:
+                    return "A19 (Metal 3)"
+                case .a19Pro:
+                    return "A19 Pro (Metal 3)"
                 case .m1:
                     return "M1 (Metal 3)"
                 case .m2:
@@ -345,6 +400,8 @@ struct DeviceUtils {
                     return "M3 (Metal 3)"
                 case .m4:
                     return "M4 (Metal 3)"
+                case .m5:
+                    return "M5 (Metal 3)"
                 case .unsupported:
                     return "Unsupported Chip"
                 case .unknown:
@@ -371,6 +428,10 @@ struct DeviceUtils {
             return "A18"
         case .a18Pro:
             return "A18 Pro"
+        case .a19:
+            return "A19"
+        case .a19Pro:
+            return "A19 Pro"
         case .m1:
             return "M1"
         case .m2:
@@ -379,6 +440,8 @@ struct DeviceUtils {
             return "M3"
         case .m4:
             return "M4"
+        case .m5:
+            return "M5"
         case .unsupported:
             return "Unsupported Chip"
         case .unknown:

--- a/Eris./Utils/MemoryManager.swift
+++ b/Eris./Utils/MemoryManager.swift
@@ -127,9 +127,9 @@ class MemoryManager {
             defaultLimit = 64 * 1024 * 1024 // 64MB for 4GB RAM devices
         case .a15:
             defaultLimit = 128 * 1024 * 1024 // 128MB for 6GB RAM devices
-        case .a16, .a17Pro, .a18, .a18Pro:
+        case .a16, .a17Pro, .a18, .a18Pro, .a19, .a19Pro:
             defaultLimit = 256 * 1024 * 1024 // 256MB for newer devices
-        case .m1, .m2, .m3, .m4:
+        case .m1, .m2, .m3, .m4, .m5:
             defaultLimit = 512 * 1024 * 1024 // 512MB for iPad M-series
         default:
             defaultLimit = 32 * 1024 * 1024 // Conservative default


### PR DESCRIPTION
## Contexto

`DeviceUtils.chipFamily` se detenía en **A18 Pro / iPad M4**, así que el hardware de 2025-2026 (iPhone 16e, iPhone 17 / 17 Pro / Pro Max, iPhone Air y los iPads recientes) resolvía a `.unknown`. Eso disparaba un fallo en cascada en `AIModelsRegistry.compatibilityForModel`: con `.unknown` (rawValue 1) el `guard chipFamily.rawValue >= minimumChipRequired.rawValue` siempre fallaba y **todos** los modelos se marcaban como *"Not recommended - High crash risk"*… justo en los dispositivos más potentes.

## Cambios

- **`ChipFamily`**: nuevos casos `a19`, `a19Pro`, `m5`.
- **Mapeo de identifiers**:
  - iPhone 16e `iPhone17,5` → A18
  - iPhone 17 `iPhone18,3` → A19
  - iPhone 17 Pro / Pro Max / Air `iPhone18,1` / `18,2` / `18,4` → A19 Pro
  - iPad mini A17 Pro `iPad16,1/2`, iPad Air M3 `iPad15,3/4`, iPad Pro M5 `iPad17,1/2`
  - M5 en detección App-on-Mac
- **Nombres comerciales** (`deviceModelName`) y `chipDescription` para todo lo anterior.
- **`estimatedRAM`**: A19 = 8 GB, A19 Pro = 12 GB, M5 = 16 GB (antes caían en el `default` de 4 GB).
- **Red de seguridad**: un chip `.unknown` con Metal 3 se trata como `.compatible` en vez de bloquearse — cubre también hardware futuro no mapeado.
- **Caché GPU** (`MemoryManager`, `LLMEvaluator`): los chips nuevos entran en las ramas de 256/512 MB en vez del `default` conservador de 32 MB.

## Pruebas

- Build OK en Xcode, sin errores ni warnings nuevos.
- Pendiente verificación en dispositivo físico (ideal: iPhone 17 / 16e).

Closes DEV-599