### PR TITLE
refactor: Migrate from mlx-swift-examples to mlx-swift-lm 3.x

### DIFF
--- a/Eris..xcodeproj/project.pbxproj
+++ b/Eris..xcodeproj/project.pbxproj
@@ -14,13 +14,9 @@
 		2ADFBF832E03F2D100B180E3 /* MLXNN in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF822E03F2D100B180E3 /* MLXNN */; };
 		2ADFBF852E03F2D100B180E3 /* MLXOptimizers in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF842E03F2D100B180E3 /* MLXOptimizers */; };
 		2ADFBF872E03F2D100B180E3 /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF862E03F2D100B180E3 /* MLXRandom */; };
-		2AE295EF2FEA8BCE00E1386B /* BenchmarkHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */; };
-		2AE295F12FEA8BCE00E1386B /* IntegrationTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */; };
-		2AE295F32FEA8BCE00E1386B /* MLXEmbedders in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F22FEA8BCE00E1386B /* MLXEmbedders */; };
 		2AE295F52FEA8BCE00E1386B /* MLXHuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */; };
 		2AE295F72FEA8BCE00E1386B /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F62FEA8BCE00E1386B /* MLXLLM */; };
 		2AE295F92FEA8BCE00E1386B /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F82FEA8BCE00E1386B /* MLXLMCommon */; };
-		2AE295FB2FEA8BCE00E1386B /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295FA2FEA8BCE00E1386B /* MLXVLM */; };
 		2AE295FE2FEA8E9C00E1386B /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295FD2FEA8E9C00E1386B /* HuggingFace */; };
 		2AE296012FEA8EA900E1386B /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE296002FEA8EA900E1386B /* Hub */; };
 		2AE296032FEA8EA900E1386B /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE296022FEA8EA900E1386B /* Tokenizers */; };
@@ -48,17 +44,13 @@
 				2ADFBF852E03F2D100B180E3 /* MLXOptimizers in Frameworks */,
 				2AE296012FEA8EA900E1386B /* Hub in Frameworks */,
 				2AE295FE2FEA8E9C00E1386B /* HuggingFace in Frameworks */,
-				2AE295F12FEA8BCE00E1386B /* IntegrationTestHelpers in Frameworks */,
 				2ADFBF7F2E03F2D100B180E3 /* MLXFast in Frameworks */,
 				2AE296052FEA8EA900E1386B /* Transformers in Frameworks */,
 				2ADFBF812E03F2D100B180E3 /* MLXLinalg in Frameworks */,
 				2AE295F52FEA8BCE00E1386B /* MLXHuggingFace in Frameworks */,
-				2AE295F32FEA8BCE00E1386B /* MLXEmbedders in Frameworks */,
 				2ADFBF7B2E03F2D100B180E3 /* MLX in Frameworks */,
 				2ADFBF832E03F2D100B180E3 /* MLXNN in Frameworks */,
 				2ADFBF7D2E03F2D100B180E3 /* MLXFFT in Frameworks */,
-				2AE295FB2FEA8BCE00E1386B /* MLXVLM in Frameworks */,
-				2AE295EF2FEA8BCE00E1386B /* BenchmarkHelpers in Frameworks */,
 				2ADFBF872E03F2D100B180E3 /* MLXRandom in Frameworks */,
 				2AE296032FEA8EA900E1386B /* Tokenizers in Frameworks */,
 				2AE295F92FEA8BCE00E1386B /* MLXLMCommon in Frameworks */,
@@ -111,13 +103,9 @@
 				2ADFBF822E03F2D100B180E3 /* MLXNN */,
 				2ADFBF842E03F2D100B180E3 /* MLXOptimizers */,
 				2ADFBF862E03F2D100B180E3 /* MLXRandom */,
-				2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */,
-				2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */,
-				2AE295F22FEA8BCE00E1386B /* MLXEmbedders */,
 				2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */,
 				2AE295F62FEA8BCE00E1386B /* MLXLLM */,
 				2AE295F82FEA8BCE00E1386B /* MLXLMCommon */,
-				2AE295FA2FEA8BCE00E1386B /* MLXVLM */,
 				2AE295FD2FEA8E9C00E1386B /* HuggingFace */,
 				2AE296002FEA8EA900E1386B /* Hub */,
 				2AE296022FEA8EA900E1386B /* Tokenizers */,
@@ -477,21 +465,6 @@
 			package = 2ADFBF792E03F2D100B180E3 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLXRandom;
 		};
-		2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = BenchmarkHelpers;
-		};
-		2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = IntegrationTestHelpers;
-		};
-		2AE295F22FEA8BCE00E1386B /* MLXEmbedders */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXEmbedders;
-		};
 		2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
@@ -506,11 +479,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLMCommon;
-		};
-		2AE295FA2FEA8BCE00E1386B /* MLXVLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXVLM;
 		};
 		2AE295FD2FEA8E9C00E1386B /* HuggingFace */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Eris..xcodeproj/project.pbxproj
+++ b/Eris..xcodeproj/project.pbxproj
@@ -14,12 +14,17 @@
 		2ADFBF832E03F2D100B180E3 /* MLXNN in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF822E03F2D100B180E3 /* MLXNN */; };
 		2ADFBF852E03F2D100B180E3 /* MLXOptimizers in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF842E03F2D100B180E3 /* MLXOptimizers */; };
 		2ADFBF872E03F2D100B180E3 /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF862E03F2D100B180E3 /* MLXRandom */; };
-		2ADFBF8A2E03F2F000B180E3 /* MLXEmbedders in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF892E03F2F000B180E3 /* MLXEmbedders */; };
-		2ADFBF8C2E03F2F000B180E3 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF8B2E03F2F000B180E3 /* MLXLLM */; };
-		2ADFBF8E2E03F2F000B180E3 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF8D2E03F2F000B180E3 /* MLXLMCommon */; };
-		2ADFBF902E03F2F000B180E3 /* MLXMNIST in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF8F2E03F2F000B180E3 /* MLXMNIST */; };
-		2ADFBF922E03F2F000B180E3 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF912E03F2F000B180E3 /* MLXVLM */; };
-		2ADFBF942E03F2F000B180E3 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = 2ADFBF932E03F2F000B180E3 /* StableDiffusion */; };
+		2AE295EF2FEA8BCE00E1386B /* BenchmarkHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */; };
+		2AE295F12FEA8BCE00E1386B /* IntegrationTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */; };
+		2AE295F32FEA8BCE00E1386B /* MLXEmbedders in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F22FEA8BCE00E1386B /* MLXEmbedders */; };
+		2AE295F52FEA8BCE00E1386B /* MLXHuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */; };
+		2AE295F72FEA8BCE00E1386B /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F62FEA8BCE00E1386B /* MLXLLM */; };
+		2AE295F92FEA8BCE00E1386B /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295F82FEA8BCE00E1386B /* MLXLMCommon */; };
+		2AE295FB2FEA8BCE00E1386B /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295FA2FEA8BCE00E1386B /* MLXVLM */; };
+		2AE295FE2FEA8E9C00E1386B /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE295FD2FEA8E9C00E1386B /* HuggingFace */; };
+		2AE296012FEA8EA900E1386B /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE296002FEA8EA900E1386B /* Hub */; };
+		2AE296032FEA8EA900E1386B /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE296022FEA8EA900E1386B /* Tokenizers */; };
+		2AE296052FEA8EA900E1386B /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE296042FEA8EA900E1386B /* Transformers */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,19 +44,24 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2ADFBF8E2E03F2F000B180E3 /* MLXLMCommon in Frameworks */,
-				2ADFBF8C2E03F2F000B180E3 /* MLXLLM in Frameworks */,
-				2ADFBF922E03F2F000B180E3 /* MLXVLM in Frameworks */,
-				2ADFBF8A2E03F2F000B180E3 /* MLXEmbedders in Frameworks */,
+				2AE295F72FEA8BCE00E1386B /* MLXLLM in Frameworks */,
 				2ADFBF852E03F2D100B180E3 /* MLXOptimizers in Frameworks */,
+				2AE296012FEA8EA900E1386B /* Hub in Frameworks */,
+				2AE295FE2FEA8E9C00E1386B /* HuggingFace in Frameworks */,
+				2AE295F12FEA8BCE00E1386B /* IntegrationTestHelpers in Frameworks */,
 				2ADFBF7F2E03F2D100B180E3 /* MLXFast in Frameworks */,
+				2AE296052FEA8EA900E1386B /* Transformers in Frameworks */,
 				2ADFBF812E03F2D100B180E3 /* MLXLinalg in Frameworks */,
-				2ADFBF902E03F2F000B180E3 /* MLXMNIST in Frameworks */,
+				2AE295F52FEA8BCE00E1386B /* MLXHuggingFace in Frameworks */,
+				2AE295F32FEA8BCE00E1386B /* MLXEmbedders in Frameworks */,
 				2ADFBF7B2E03F2D100B180E3 /* MLX in Frameworks */,
 				2ADFBF832E03F2D100B180E3 /* MLXNN in Frameworks */,
 				2ADFBF7D2E03F2D100B180E3 /* MLXFFT in Frameworks */,
-				2ADFBF942E03F2F000B180E3 /* StableDiffusion in Frameworks */,
+				2AE295FB2FEA8BCE00E1386B /* MLXVLM in Frameworks */,
+				2AE295EF2FEA8BCE00E1386B /* BenchmarkHelpers in Frameworks */,
 				2ADFBF872E03F2D100B180E3 /* MLXRandom in Frameworks */,
+				2AE296032FEA8EA900E1386B /* Tokenizers in Frameworks */,
+				2AE295F92FEA8BCE00E1386B /* MLXLMCommon in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,12 +111,17 @@
 				2ADFBF822E03F2D100B180E3 /* MLXNN */,
 				2ADFBF842E03F2D100B180E3 /* MLXOptimizers */,
 				2ADFBF862E03F2D100B180E3 /* MLXRandom */,
-				2ADFBF892E03F2F000B180E3 /* MLXEmbedders */,
-				2ADFBF8B2E03F2F000B180E3 /* MLXLLM */,
-				2ADFBF8D2E03F2F000B180E3 /* MLXLMCommon */,
-				2ADFBF8F2E03F2F000B180E3 /* MLXMNIST */,
-				2ADFBF912E03F2F000B180E3 /* MLXVLM */,
-				2ADFBF932E03F2F000B180E3 /* StableDiffusion */,
+				2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */,
+				2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */,
+				2AE295F22FEA8BCE00E1386B /* MLXEmbedders */,
+				2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */,
+				2AE295F62FEA8BCE00E1386B /* MLXLLM */,
+				2AE295F82FEA8BCE00E1386B /* MLXLMCommon */,
+				2AE295FA2FEA8BCE00E1386B /* MLXVLM */,
+				2AE295FD2FEA8E9C00E1386B /* HuggingFace */,
+				2AE296002FEA8EA900E1386B /* Hub */,
+				2AE296022FEA8EA900E1386B /* Tokenizers */,
+				2AE296042FEA8EA900E1386B /* Transformers */,
 			);
 			productName = Eris.;
 			productReference = 2ADFBF6B2E03F10F00B180E3 /* Eris..app */;
@@ -138,7 +153,9 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				2ADFBF792E03F2D100B180E3 /* XCRemoteSwiftPackageReference "mlx-swift" */,
-				2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
+				2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+				2AE295FC2FEA8E9C00E1386B /* XCRemoteSwiftPackageReference "swift-huggingface" */,
+				2AE295FF2FEA8EA900E1386B /* XCRemoteSwiftPackageReference "swift-transformers" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2ADFBF6C2E03F10F00B180E3 /* Products */;
@@ -394,13 +411,33 @@
 				minimumVersion = 0.25.4;
 			};
 		};
-		2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
+		2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples";
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.25.4;
+				minimumVersion = 3.31.3;
 			};
+		};
+		2AE295FC2FEA8E9C00E1386B /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-huggingface";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+			traits = (
+			);
+		};
+		2AE295FF2FEA8EA900E1386B /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-transformers";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.3;
+			};
+			traits = (
+			);
 		};
 /* End XCRemoteSwiftPackageReference section */
 
@@ -440,35 +477,60 @@
 			package = 2ADFBF792E03F2D100B180E3 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLXRandom;
 		};
-		2ADFBF892E03F2F000B180E3 /* MLXEmbedders */ = {
+		2AE295EE2FEA8BCE00E1386B /* BenchmarkHelpers */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = BenchmarkHelpers;
+		};
+		2AE295F02FEA8BCE00E1386B /* IntegrationTestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = IntegrationTestHelpers;
+		};
+		2AE295F22FEA8BCE00E1386B /* MLXEmbedders */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXEmbedders;
 		};
-		2ADFBF8B2E03F2F000B180E3 /* MLXLLM */ = {
+		2AE295F42FEA8BCE00E1386B /* MLXHuggingFace */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXHuggingFace;
+		};
+		2AE295F62FEA8BCE00E1386B /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLLM;
 		};
-		2ADFBF8D2E03F2F000B180E3 /* MLXLMCommon */ = {
+		2AE295F82FEA8BCE00E1386B /* MLXLMCommon */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLMCommon;
 		};
-		2ADFBF8F2E03F2F000B180E3 /* MLXMNIST */ = {
+		2AE295FA2FEA8BCE00E1386B /* MLXVLM */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = MLXMNIST;
-		};
-		2ADFBF912E03F2F000B180E3 /* MLXVLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 2AE295ED2FEA8BCE00E1386B /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXVLM;
 		};
-		2ADFBF932E03F2F000B180E3 /* StableDiffusion */ = {
+		2AE295FD2FEA8E9C00E1386B /* HuggingFace */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2ADFBF882E03F2F000B180E3 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = StableDiffusion;
+			package = 2AE295FC2FEA8E9C00E1386B /* XCRemoteSwiftPackageReference "swift-huggingface" */;
+			productName = HuggingFace;
+		};
+		2AE296002FEA8EA900E1386B /* Hub */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295FF2FEA8EA900E1386B /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Hub;
+		};
+		2AE296022FEA8EA900E1386B /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295FF2FEA8EA900E1386B /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
+		};
+		2AE296042FEA8EA900E1386B /* Transformers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AE295FF2FEA8EA900E1386B /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Transformers;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Eris..xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Eris..xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d5548070f49c13d9d554b1dd96f1b3bf426387a5a1e154c2bf471dd59d212a66",
+  "originHash" : "46d8193fe91ecec1a58adc572540d20c94e368d77b3556cc81870f008c4371fe",
   "pins" : [
     {
-      "identity" : "gzipswift",
+      "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/1024jp/GzipSwift",
+      "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
-        "version" : "6.0.1"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -15,17 +15,35 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
-        "version" : "0.29.1"
+        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
+        "version" : "0.31.4"
       }
     },
     {
-      "identity" : "mlx-swift-examples",
+      "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-examples",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
       "state" : {
-        "revision" : "9bff95ca5f0b9e8c021acc4d71a2bbe4a7441631",
-        "version" : "2.29.1"
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -33,8 +51,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
       }
     },
     {
@@ -42,8 +78,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "ba2364165002abe8f4f3992d74a7b547c635638e",
-        "version" : "2.2.1"
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
       }
     },
     {
@@ -56,12 +101,39 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "a2e184dddb4757bc943e77fbe99ac6786c53f0b2",
-        "version" : "1.0.0"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Eris./Models/LLMEvaluator.swift
+++ b/Eris./Models/LLMEvaluator.swift
@@ -48,7 +48,6 @@ class LLMEvaluator: ObservableObject {
     @Published var tokensGenerated = 0
     
     private var modelConfiguration: ModelConfiguration?
-    private let maxTokens = 2048
     private let generateParameters = GenerateParameters(maxTokens: 2048, temperature: 0.7)
     private let cancellationToken = CancellationToken()
     

--- a/Eris./Models/LLMEvaluator.swift
+++ b/Eris./Models/LLMEvaluator.swift
@@ -8,7 +8,10 @@
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXHuggingFace
 import MLXRandom
+import HuggingFace
+import Tokenizers
 import SwiftUI
 
 // Helper class to manage cancellation state across actor boundaries
@@ -45,8 +48,8 @@ class LLMEvaluator: ObservableObject {
     @Published var tokensGenerated = 0
     
     private var modelConfiguration: ModelConfiguration?
-    private let generateParameters = GenerateParameters(temperature: 0.7)
     private let maxTokens = 2048
+    private let generateParameters = GenerateParameters(maxTokens: 2048, temperature: 0.7)
     private let cancellationToken = CancellationToken()
     
     enum LoadState {
@@ -70,7 +73,7 @@ class LLMEvaluator: ObservableObject {
             // Use conservative cache limit during model loading
             // Similar to Fullmoon's approach for better stability
             let cacheLimit = 20 * 1024 * 1024 // 20MB during initial load
-            MLX.GPU.set(cacheLimit: cacheLimit)
+            MLX.Memory.cacheLimit = cacheLimit
             print("GPU cache limit set to: \(cacheLimit / 1024 / 1024)MB for model loading")
             
             do {
@@ -85,10 +88,12 @@ class LLMEvaluator: ObservableObject {
                     try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
                     
                     // Set minimal cache
-                    MLX.GPU.set(cacheLimit: 16 * 1024 * 1024) // 16MB minimum
+                    MLX.Memory.cacheLimit = 16 * 1024 * 1024 // 16MB minimum
                 }
                 
                 let modelContainer = try await LLMModelFactory.shared.loadContainer(
+                    from: #hubDownloader(),
+                    using: #huggingFaceTokenizerLoader(),
                     configuration: modelConfiguration
                 ) { progress in
                     Task { @MainActor in
@@ -103,7 +108,7 @@ class LLMEvaluator: ObservableObject {
                 
                 // After successful load, adjust cache based on device
                 let runtimeCacheLimit = getCacheLimitForDevice()
-                MLX.GPU.set(cacheLimit: runtimeCacheLimit)
+                MLX.Memory.cacheLimit = runtimeCacheLimit
                 print("Runtime cache limit adjusted to: \(runtimeCacheLimit / 1024 / 1024)MB")
                 
                 return modelContainer
@@ -143,7 +148,6 @@ class LLMEvaluator: ObservableObject {
     
     private func getCacheLimitForDevice() -> Int {
         // Get device info
-        let deviceModel = DeviceUtils.deviceModel
         let chipFamily = DeviceUtils.chipFamily
         
         // Base cache sizes in MB
@@ -192,55 +196,43 @@ class LLMEvaluator: ObservableObject {
             let modelContainer = try await load()
             isLoadingModel = false
             
-            // Prepare conversation history
-            var messages: [[String: String]] = []
-            
-            // Add system prompt
-            messages.append([
-                "role": "system",
-                "content": systemPrompt
-            ])
-            
-            // Add conversation history
+            // Build the structured chat history (system prompt + conversation)
+            var chat: [Chat.Message] = [.system(systemPrompt)]
             for message in thread.sortedMessages {
-                messages.append([
-                    "role": message.role.rawValue,
-                    "content": message.content
-                ])
-            }
-            
-            // Generate random seed
-            MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
-            
-            let cancellationToken = self.cancellationToken
-            
-            let result = try await modelContainer.perform { [weak self] context in
-                let input = try await context.processor.prepare(input: .init(messages: messages))
-                return try MLXLMCommon.generate(
-                    input: input,
-                    parameters: generateParameters,
-                    context: context
-                ) { tokens in
-                    guard let self = self else { return .stop }
-                    
-                    // Update output periodically
-                    if tokens.count % 4 == 0 {
-                        let text = context.tokenizer.decode(tokens: tokens)
-                        Task { @MainActor in
-                            self.output = text
-                            self.tokensGenerated = tokens.count
-                        }
-                    }
-                    
-                    // Check if we should stop generation
-                    if cancellationToken.isCancelled {
-                        return .stop
-                    }
-                    return tokens.count >= maxTokens ? .stop : .more
+                switch message.role {
+                case .user:
+                    chat.append(.user(message.content))
+                case .assistant:
+                    chat.append(.assistant(message.content))
+                case .system:
+                    chat.append(.system(message.content))
                 }
             }
-            
-            output = result.output
+
+            // Generate random seed
+            MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
+
+            // Prepare input and stream the generation (mlx-swift-lm 3.x AsyncStream API)
+            let lmInput = try await modelContainer.prepare(input: UserInput(chat: chat))
+            let stream = try await modelContainer.generate(
+                input: lmInput,
+                parameters: generateParameters
+            )
+
+            var generatedText = ""
+            for await generation in stream {
+                if cancellationToken.isCancelled { break }
+                switch generation {
+                case .chunk(let text):
+                    generatedText += text
+                    output = generatedText
+                    tokensGenerated += 1
+                case .info, .toolCall:
+                    break
+                }
+            }
+
+            output = generatedText
             
         } catch {
             // Provide more helpful error messages

--- a/Eris./Models/ModelManager.swift
+++ b/Eris./Models/ModelManager.swift
@@ -9,6 +9,9 @@ import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXHuggingFace
+import HuggingFace
+import Tokenizers
 import SwiftUI
 
 // Custom error types for better error handling
@@ -131,7 +134,7 @@ class ModelManager: ObservableObject {
         // Use lower cache limit for better compatibility with cellular connections
         // Similar to Fullmoon's approach (20MB)
         let cacheLimit = 20 * 1024 * 1024 // 20MB for all devices during download
-        MLX.GPU.set(cacheLimit: cacheLimit)
+        MLX.Memory.cacheLimit = cacheLimit
         print("Download cache limit set to: \(cacheLimit / 1024 / 1024)MB")
         
         var lastError: Error?
@@ -150,6 +153,8 @@ class ModelManager: ObservableObject {
                 // Download the model
                 print("Download attempt \(attempt + 1) of \(maxRetries)")
                 _ = try await LLMModelFactory.shared.loadContainer(
+                    from: #hubDownloader(),
+                    using: #huggingFaceTokenizerLoader(),
                     configuration: model,
                     progressHandler: { progress in
                         print("Download progress: \(progress.fractionCompleted)")

--- a/Eris./Models/ModelManager.swift
+++ b/Eris./Models/ModelManager.swift
@@ -276,21 +276,36 @@ class ModelManager: ObservableObject {
     
     private func deleteModelFiles(for model: ModelConfiguration) {
         let fileManager = FileManager.default
-        
-        // Try to find and delete model files in Documents/huggingface
+
+        // mlx-swift-lm 3.x downloads through swift-huggingface's HubClient, which caches under
+        // <app>/Library/Caches/huggingface/hub/models--<namespace>--<name> on iOS. Ask the
+        // library's own cache for the directory so the path always matches where the weights
+        // were actually written (and keeps working if the convention changes upstream).
+        if let repo = Repo.ID(rawValue: model.name) {
+            let cache = HubCache.default
+            let directories = [
+                cache.repoDirectory(repo: repo, kind: .model),
+                cache.metadataDirectory(repo: repo, kind: .model)
+            ]
+            for directory in directories where fileManager.fileExists(atPath: directory.path) {
+                do {
+                    try fileManager.removeItem(at: directory)
+                    print("Deleted model files at: \(directory.path)")
+                } catch {
+                    print("Error deleting model files at \(directory.path): \(error)")
+                }
+            }
+        }
+
+        // Legacy cleanup: models downloaded by the old mlx-swift-examples HubApi lived in
+        // Documents/huggingface/models/<name>. Remove those too for users upgrading from 2.x.
         if let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let modelPath = documentsPath
+            let legacyPath = documentsPath
                 .appendingPathComponent("huggingface")
                 .appendingPathComponent("models")
                 .appendingPathComponent(model.name)
-            
-            do {
-                if fileManager.fileExists(atPath: modelPath.path) {
-                    try fileManager.removeItem(at: modelPath)
-                    print("Deleted model files at: \(modelPath)")
-                }
-            } catch {
-                print("Error deleting model files: \(error)")
+            if fileManager.fileExists(atPath: legacyPath.path) {
+                try? fileManager.removeItem(at: legacyPath)
             }
         }
     }

--- a/Eris./Utils/MemoryManager.swift
+++ b/Eris./Utils/MemoryManager.swift
@@ -55,7 +55,7 @@ class MemoryManager {
             reducedLimit = 128 * 1024 * 1024 // 128MB
         }
         
-        MLX.GPU.set(cacheLimit: reducedLimit)
+        MLX.Memory.cacheLimit = reducedLimit
         print("✓ Reduced GPU cache limit to \(reducedLimit/1024/1024)MB for \(DeviceUtils.chipDescription)")
         
         // 2. Clear any image caches
@@ -135,7 +135,7 @@ class MemoryManager {
             defaultLimit = 32 * 1024 * 1024 // Conservative default
         }
         
-        MLX.GPU.set(cacheLimit: defaultLimit)
+        MLX.Memory.cacheLimit = defaultLimit
         print("✓ Reset GPU cache limit to \(defaultLimit/1024/1024)MB for \(DeviceUtils.chipDescription)")
     }
 }


### PR DESCRIPTION
## Contexto

`mlx-swift-examples` (2.29.1) está **archivado**: las librerías se movieron a `mlx-swift-lm` (3.x). Además, ese paquete fijaba `mlx-swift` a `< 0.30`, bloqueando cualquier actualización. Esta PR migra al repo nuevo y reescribe la inferencia a la API 3.x.

## Cambios de dependencias (SPM)

- `mlx-swift-examples` 2.29.1 → **`mlx-swift-lm` 3.31.3**.
- `mlx-swift` 0.29.1 → **0.31.4** (lo arrastra `mlx-swift-lm`).
- **Añadidos** `swift-huggingface` (`HuggingFace`, HubClient) y `swift-transformers` (`Tokenizers`): en 2.x venían incluidos; en 3.x el paquete solo provee *macros* y la app debe aportar el cliente de Hub y el tokenizer.
- Desaparecen `swift-transformers`/`jinja`/`collections`/`gzip` como deps directas heredadas, y `MLXMNIST`/`StableDiffusion` (eran exclusivos de `examples`).

## Reescritura (`LLMEvaluator`, `ModelManager`)

- **Carga**: `LLMModelFactory.shared.loadContainer(from: #hubDownloader(), using: #huggingFaceTokenizerLoader(), configuration:, progressHandler:)` (macros de `MLXHuggingFace`).
- **Input**: historial estructurado con `UserInput(chat: [.system/.user/.assistant])` en lugar de los diccionarios `[[String: String]]`.
- **Generación**: stream `AsyncStream<Generation>`, consumiendo eventos `.chunk`; cancelación rompiendo el `for await`.
- `GenerateParameters(maxTokens:)` y migración de `MLX.GPU.set(cacheLimit:)` (deprecado) → `MLX.Memory.cacheLimit`.

## Pruebas

- Build OK en Xcode (0 errores, 0 warnings en los archivos tocados).
- Probado en dispositivo: descarga de modelo + generación con streaming funcionando.

## Notas / seguimiento

- El nuevo `HubClient` usa la caché estándar de Hugging Face (`~/.cache/huggingface/…`); `ModelManager.deleteModelFiles` aún apunta a la ruta antigua (`Documents/huggingface/…`). Pendiente de verificar/ajustar el borrado de modelos.
- Productos SPM sobrantes en el target (`BenchmarkHelpers`, `IntegrationTestHelpers`, `MLXEmbedders`, `MLXVLM`) a limpiar.
- La detección de chips (iPhone 17 Pro Max marcado como *high risk*) se corrige en DEV-599 (PR #7), no incluida en esta branch.
- El refresco del catálogo de modelos es DEV-600.

Closes DEV-596