### PR TITLE
refactor: Introduce ChatEngine inference abstraction and ModelSource

### DIFF
--- a/Eris./Intents/IntentUtils.swift
+++ b/Eris./Intents/IntentUtils.swift
@@ -29,8 +29,8 @@ enum IntentError: LocalizedError {
 @available(iOS 16.0, *)
 @MainActor
 struct IntentUtils {
-    // Shared LLM evaluator for all intents to improve performance
-    static let sharedLLMEvaluator = LLMEvaluator()
+    // Shared chat engine runner for all intents to improve performance
+    static let sharedRunner = ChatEngineRunner()
     
     /// Selects the appropriate model based on user input or defaults to active model
     static func selectModel(requestedName: String?) -> Result<MLXLMCommon.ModelConfiguration, IntentError> {
@@ -91,8 +91,8 @@ struct IntentUtils {
             modelManager.setActiveModel(model)
         }
         
-        // Use the shared LLM evaluator for better performance
-        let response = await sharedLLMEvaluator.generate(
+        // Use the shared chat engine runner for better performance
+        let response = await sharedRunner.generate(
             thread: thread,
             systemPrompt: systemPrompt
         )

--- a/Eris./Models/AIModels.swift
+++ b/Eris./Models/AIModels.swift
@@ -70,7 +70,7 @@ enum ModelCompatibility {
 // MARK: - AI Model
 struct AIModel: Identifiable {
     let id: String
-    let configuration: ModelConfiguration
+    let source: ModelSource
     let category: ModelCategory
     let displayName: String
     let description: String
@@ -80,6 +80,33 @@ struct AIModel: Identifiable {
     let quantization: String // e.g., "4-bit", "8-bit"
     let isLegacy: Bool // For older models kept for compatibility
 
+    /// General initializer covering any `ModelSource`.
+    init(
+        id: String,
+        source: ModelSource,
+        category: ModelCategory,
+        displayName: String,
+        description: String,
+        estimatedRAMUsage: Int,
+        minimumChipRequired: DeviceUtils.ChipFamily,
+        parameterCount: String,
+        quantization: String,
+        isLegacy: Bool = false
+    ) {
+        self.id = id
+        self.source = source
+        self.category = category
+        self.displayName = displayName
+        self.description = description
+        self.estimatedRAMUsage = estimatedRAMUsage
+        self.minimumChipRequired = minimumChipRequired
+        self.parameterCount = parameterCount
+        self.quantization = quantization
+        self.isLegacy = isLegacy
+    }
+
+    /// Convenience initializer for MLX-backed models. Keeps the registry
+    /// declarations unchanged while `source` becomes the source of truth.
     init(
         id: String,
         configuration: ModelConfiguration,
@@ -92,20 +119,28 @@ struct AIModel: Identifiable {
         quantization: String,
         isLegacy: Bool = false
     ) {
-        self.id = id
-        self.configuration = configuration
-        self.category = category
-        self.displayName = displayName
-        self.description = description
-        self.estimatedRAMUsage = estimatedRAMUsage
-        self.minimumChipRequired = minimumChipRequired
-        self.parameterCount = parameterCount
-        self.quantization = quantization
-        self.isLegacy = isLegacy
+        self.init(
+            id: id,
+            source: .mlx(configuration),
+            category: category,
+            displayName: displayName,
+            description: description,
+            estimatedRAMUsage: estimatedRAMUsage,
+            minimumChipRequired: minimumChipRequired,
+            parameterCount: parameterCount,
+            quantization: quantization,
+            isLegacy: isLegacy
+        )
+    }
+
+    /// The MLX configuration when this model is MLX-backed, otherwise `nil`.
+    var mlxConfiguration: ModelConfiguration? {
+        if case .mlx(let configuration) = source { return configuration }
+        return nil
     }
 
     var fullName: String {
-        configuration.name
+        mlxConfiguration?.name ?? displayName
     }
 
     var shortName: String {
@@ -299,11 +334,11 @@ class AIModelsRegistry {
     }
 
     func modelByConfiguration(_ configuration: ModelConfiguration) -> AIModel? {
-        models.first { $0.configuration.name == configuration.name }
+        models.first { $0.mlxConfiguration?.name == configuration.name }
     }
 
     func modelByName(_ name: String) -> AIModel? {
-        models.first { $0.configuration.name == name }
+        models.first { $0.mlxConfiguration?.name == name }
     }
 
     func modelById(_ id: String) -> AIModel? {
@@ -386,15 +421,16 @@ class AIModelsRegistry {
 // MARK: - Extensions for backward compatibility
 extension ModelConfiguration {
     static var availableModels: [ModelConfiguration] {
-        AIModelsRegistry.shared.allModels.map { $0.configuration }
+        AIModelsRegistry.shared.allModels.compactMap { $0.mlxConfiguration }
     }
 
     static var defaultModel: ModelConfiguration {
-        AIModelsRegistry.shared.defaultModel.configuration
+        let defaultAIModel = AIModelsRegistry.shared.defaultModel
+        return defaultAIModel.mlxConfiguration ?? ModelConfiguration(id: defaultAIModel.id)
     }
 
     static func getModelByName(_ name: String) -> ModelConfiguration? {
-        AIModelsRegistry.shared.modelByName(name)?.configuration
+        AIModelsRegistry.shared.modelByName(name)?.mlxConfiguration
     }
 }
 

--- a/Eris./Models/Engines/ChatEngine.swift
+++ b/Eris./Models/Engines/ChatEngine.swift
@@ -1,0 +1,42 @@
+//
+//  ChatEngine.swift
+//  Eris.
+//
+//  Inference-provider abstraction introduced in DEV-597.
+//
+
+import Foundation
+
+/// Receives incremental generation updates from a `ChatEngine` so a UI-facing
+/// observable (e.g. `ChatEngineRunner`) can republish them as `@Published` state.
+@MainActor
+protocol ChatEngineDelegate: AnyObject {
+    /// The engine started or finished the (possibly slow) model loading phase.
+    func chatEngine(_ engine: ChatEngine, didChangeLoadingState isLoading: Bool)
+
+    /// Download/preparation progress in the `0...1` range (MLX only).
+    func chatEngine(_ engine: ChatEngine, didUpdateDownloadProgress fraction: Double)
+
+    /// New cumulative output text together with the running token count.
+    func chatEngine(_ engine: ChatEngine, didProduceOutput cumulativeText: String, tokenCount: Int)
+}
+
+/// A backend capable of producing a chat completion for a conversation.
+///
+/// Concrete engines:
+/// - `MLXEngine` — on-device MLX model downloaded from Hugging Face.
+/// - `FoundationModelsEngine` — Apple's system model (added in DEV-598).
+///
+/// Engines report streaming progress through `delegate` and return the final
+/// text. They never touch UI state directly, which keeps them reusable from
+/// both `ChatView` and App Intents.
+@MainActor
+protocol ChatEngine: AnyObject {
+    /// Generates a response for `thread` using `systemPrompt`, streaming partial
+    /// output through `delegate`. Returns the final, complete text (or a
+    /// user-facing error string on failure).
+    func generate(thread: Thread, systemPrompt: String, delegate: ChatEngineDelegate) async -> String
+
+    /// Requests cancellation of the in-flight generation, if any.
+    func cancel()
+}

--- a/Eris./Models/Engines/ChatEngineRunner.swift
+++ b/Eris./Models/Engines/ChatEngineRunner.swift
@@ -1,0 +1,82 @@
+//
+//  ChatEngineRunner.swift
+//  Eris.
+//
+//  UI-facing coordinator that drives a `ChatEngine` and republishes its
+//  streaming state. Replaces the role `LLMEvaluator` used to play for the two
+//  generation call-sites (ChatView and App Intents). Introduced in DEV-597.
+//
+
+import SwiftUI
+
+@MainActor
+final class ChatEngineRunner: ObservableObject, ChatEngineDelegate {
+    @Published var running = false
+    @Published var isLoadingModel = false
+    @Published var output = ""
+    @Published var progress = 0.0
+    @Published var tokensGenerated = 0
+
+    // Concrete engines are cached so each keeps its own load state across
+    // messages (the MLX engine caches the loaded `ModelContainer`).
+    private lazy var mlxEngine = MLXEngine()
+    private var currentEngine: ChatEngine?
+
+    /// Resolves the engine for a given source. DEV-598 will return a
+    /// `FoundationModelsEngine` for `.appleFoundation`.
+    private func engine(for source: ModelSource) -> ChatEngine {
+        switch source {
+        case .mlx:
+            return mlxEngine
+        case .appleFoundation:
+            // Placeholder until DEV-598 wires up Apple Foundation Models.
+            return mlxEngine
+        }
+    }
+
+    func generate(thread: Thread, systemPrompt: String = "You are a helpful assistant.") async -> String {
+        guard !running else { return "" }
+
+        running = true
+        output = ""
+        tokensGenerated = 0
+        progress = 0
+        isLoadingModel = false
+
+        guard let aiModel = ModelManager.shared.activeAIModel else {
+            output = "Error: No model selected"
+            running = false
+            return output
+        }
+
+        let engine = engine(for: aiModel.source)
+        currentEngine = engine
+
+        let result = await engine.generate(thread: thread, systemPrompt: systemPrompt, delegate: self)
+
+        output = result
+        running = false
+        currentEngine = nil
+        return result
+    }
+
+    /// Requests cancellation of the in-flight generation.
+    func stop() {
+        (currentEngine ?? mlxEngine).cancel()
+    }
+
+    // MARK: - ChatEngineDelegate
+
+    func chatEngine(_ engine: ChatEngine, didChangeLoadingState isLoading: Bool) {
+        isLoadingModel = isLoading
+    }
+
+    func chatEngine(_ engine: ChatEngine, didUpdateDownloadProgress fraction: Double) {
+        progress = fraction
+    }
+
+    func chatEngine(_ engine: ChatEngine, didProduceOutput cumulativeText: String, tokenCount: Int) {
+        output = cumulativeText
+        tokensGenerated = tokenCount
+    }
+}

--- a/Eris./Models/Engines/MLXEngine.swift
+++ b/Eris./Models/Engines/MLXEngine.swift
@@ -1,8 +1,11 @@
 //
-//  LLMEvaluator.swift
+//  MLXEngine.swift
 //  Eris.
 //
-//  Created by Ignacio Palacio on 19/6/25.
+//  MLX-backed `ChatEngine`. This is the former `LLMEvaluator`, with its inference
+//  logic kept intact (DEV-597). UI state is now reported through `ChatEngineDelegate`
+//  instead of `@Published` properties so the engine can sit behind the `ChatEngine`
+//  abstraction.
 //
 
 import MLX
@@ -15,22 +18,22 @@ import Tokenizers
 import SwiftUI
 
 // Helper class to manage cancellation state across actor boundaries
-class CancellationToken {
+final class CancellationToken {
     private var _isCancelled = false
     private let lock = NSLock()
-    
+
     var isCancelled: Bool {
         lock.lock()
         defer { lock.unlock() }
         return _isCancelled
     }
-    
+
     func cancel() {
         lock.lock()
         defer { lock.unlock() }
         _isCancelled = true
     }
-    
+
     func reset() {
         lock.lock()
         defer { lock.unlock() }
@@ -39,119 +42,112 @@ class CancellationToken {
 }
 
 @MainActor
-class LLMEvaluator: ObservableObject {
-    @Published var running = false
-    @Published var isLoadingModel = false
-    @Published var output = ""
-    @Published var modelInfo = ""
-    @Published var progress = 0.0
-    @Published var tokensGenerated = 0
-    
-    private var modelConfiguration: ModelConfiguration?
+final class MLXEngine: ChatEngine {
     private let generateParameters = GenerateParameters(maxTokens: 2048, temperature: 0.7)
     private let cancellationToken = CancellationToken()
-    
+
+    /// Set for the duration of a `generate` call so the loading phase can report progress.
+    private weak var delegate: ChatEngineDelegate?
+
     enum LoadState {
         case idle
         case loading
         case loaded(ModelContainer)
         case failed(Error)
     }
-    
+
     var loadState = LoadState.idle
-    
+
+    func cancel() {
+        cancellationToken.cancel()
+    }
+
     func load() async throws -> ModelContainer {
         guard let modelConfiguration = ModelManager.shared.activeModel else {
-            throw NSError(domain: "LLMEvaluator", code: 1, userInfo: [NSLocalizedDescriptionKey: "No model selected"])
+            throw NSError(domain: "MLXEngine", code: 1, userInfo: [NSLocalizedDescriptionKey: "No model selected"])
         }
         switch loadState {
         case .idle, .failed:
             loadState = .loading
-            isLoadingModel = true
-            
+            delegate?.chatEngine(self, didChangeLoadingState: true)
+
             // Use conservative cache limit during model loading
             // Similar to Fullmoon's approach for better stability
             let cacheLimit = 20 * 1024 * 1024 // 20MB during initial load
             MLX.Memory.cacheLimit = cacheLimit
             print("GPU cache limit set to: \(cacheLimit / 1024 / 1024)MB for model loading")
-            
+
             do {
                 // For low-memory devices, use compatibility mode
                 if DeviceUtils.chipFamily == .a13 || DeviceUtils.chipFamily == .a14 {
                     print("⏳ Using compatibility mode for limited memory device...")
-                    
+
                     // Force memory cleanup
                     MemoryManager.shared.performLowMemoryCleanup()
-                    
+
                     // Wait for system to stabilize
                     try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
-                    
+
                     // Set minimal cache
                     MLX.Memory.cacheLimit = 16 * 1024 * 1024 // 16MB minimum
                 }
-                
+
                 let modelContainer = try await LLMModelFactory.shared.loadContainer(
                     from: #hubDownloader(),
                     using: #huggingFaceTokenizerLoader(),
                     configuration: modelConfiguration
                 ) { progress in
                     Task { @MainActor in
-                        self.modelInfo = "Downloading: \(Int(progress.fractionCompleted * 100))%"
-                        self.progress = progress.fractionCompleted
+                        self.delegate?.chatEngine(self, didUpdateDownloadProgress: progress.fractionCompleted)
                     }
                 }
-                
-                modelInfo = "Model loaded successfully"
+
                 loadState = .loaded(modelContainer)
-                isLoadingModel = false
-                
+                delegate?.chatEngine(self, didChangeLoadingState: false)
+
                 // After successful load, adjust cache based on device
                 let runtimeCacheLimit = getCacheLimitForDevice()
                 MLX.Memory.cacheLimit = runtimeCacheLimit
                 print("Runtime cache limit adjusted to: \(runtimeCacheLimit / 1024 / 1024)MB")
-                
+
                 return modelContainer
-                
+
             } catch {
                 loadState = .failed(error)
-                isLoadingModel = false
-                
+                delegate?.chatEngine(self, didChangeLoadingState: false)
+
                 // Log detailed error information
                 print("❌ Failed to load model: \(error)")
-                
+
                 // Check if it's a Metal compilation error
                 let errorDescription = error.localizedDescription.lowercased()
                 if errorDescription.contains("metal") || errorDescription.contains("kernel") || errorDescription.contains("xpc_error") {
                     print("⚠️ Metal compilation error detected. This may be due to memory constraints.")
                     print("💡 Try closing other apps and restarting the device.")
                 }
-                
+
                 throw error
             }
-            
+
         case .loading:
             // Wait for current load
             while case .loading = loadState {
                 try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
             }
             return try await load()
-            
+
         case let .loaded(modelContainer):
             return modelContainer
         }
     }
-    
-    func stopGeneration() {
-        cancellationToken.cancel()
-    }
-    
+
     private func getCacheLimitForDevice() -> Int {
         // Get device info
         let chipFamily = DeviceUtils.chipFamily
-        
+
         // Base cache sizes in MB
         let baseCacheSize: Int
-        
+
         switch chipFamily {
         case .a13, .a14:
             // iPhone 11, 12 series - 4GB RAM devices
@@ -169,32 +165,29 @@ class LLMEvaluator: ObservableObject {
             // Conservative default
             baseCacheSize = 32
         }
-        
+
         return baseCacheSize * 1024 * 1024
     }
-    
-    func generate(thread: Thread, systemPrompt: String = "You are a helpful assistant.") async -> String {
-        guard !running else { return "" }
-        
-        running = true
-        output = ""
-        tokensGenerated = 0
+
+    func generate(thread: Thread, systemPrompt: String, delegate: ChatEngineDelegate) async -> String {
+        self.delegate = delegate
         cancellationToken.reset()
-        
+
+        var output = ""
+        var tokensGenerated = 0
+
         do {
-            // Check if model needs to be loaded
+            // Reflect the initial loading state to the delegate
             switch loadState {
-            case .idle, .failed:
-                isLoadingModel = true
-            case .loading:
-                isLoadingModel = true
+            case .idle, .failed, .loading:
+                delegate.chatEngine(self, didChangeLoadingState: true)
             case .loaded:
-                isLoadingModel = false
+                delegate.chatEngine(self, didChangeLoadingState: false)
             }
-            
+
             let modelContainer = try await load()
-            isLoadingModel = false
-            
+            delegate.chatEngine(self, didChangeLoadingState: false)
+
             // Build the structured chat history (system prompt + conversation)
             var chat: [Chat.Message] = [.system(systemPrompt)]
             for message in thread.sortedMessages {
@@ -218,25 +211,22 @@ class LLMEvaluator: ObservableObject {
                 parameters: generateParameters
             )
 
-            var generatedText = ""
             for await generation in stream {
                 if cancellationToken.isCancelled { break }
                 switch generation {
                 case .chunk(let text):
-                    generatedText += text
-                    output = generatedText
+                    output += text
                     tokensGenerated += 1
+                    delegate.chatEngine(self, didProduceOutput: output, tokenCount: tokensGenerated)
                 case .info, .toolCall:
                     break
                 }
             }
 
-            output = generatedText
-            
         } catch {
             // Provide more helpful error messages
             let errorDescription = error.localizedDescription.lowercased()
-            
+
             if errorDescription.contains("metal") || errorDescription.contains("kernel") || errorDescription.contains("xpc_error") {
                 output = "Error: Unable to load model due to memory constraints. Please try:\n1. Close other apps\n2. Restart your device\n3. Try a smaller model (0.5B or 1B)"
             } else if errorDescription.contains("memory") {
@@ -244,11 +234,12 @@ class LLMEvaluator: ObservableObject {
             } else {
                 output = "Error: \(error.localizedDescription)"
             }
-            
+
+            delegate.chatEngine(self, didProduceOutput: output, tokenCount: tokensGenerated)
             print("❌ Generation error: \(error)")
         }
-        
-        running = false
+
+        self.delegate = nil
         return output
     }
 }

--- a/Eris./Models/ModelManager.swift
+++ b/Eris./Models/ModelManager.swift
@@ -67,9 +67,12 @@ class ModelManager: ObservableObject {
     }
     
     private func loadActiveModel() {
-        if let modelName = userDefaults.string(forKey: activeModelKey),
-           let aiModel = AIModelsRegistry.shared.modelByName(modelName) {
-            activeModel = aiModel.configuration
+        guard let storedKey = userDefaults.string(forKey: activeModelKey) else { return }
+        // Stored value is the MLX repo name for MLX models, or the model id for
+        // sources without a configuration (e.g. Apple Foundation, DEV-598).
+        if let aiModel = AIModelsRegistry.shared.modelByName(storedKey)
+            ?? AIModelsRegistry.shared.modelById(storedKey) {
+            activeModel = aiModel.mlxConfiguration
             activeAIModel = aiModel
         }
     }
@@ -252,28 +255,97 @@ class ModelManager: ObservableObject {
         // If this was the active model, clear it
         if activeModel?.name == model.name {
             activeModel = nil
+            activeAIModel = nil
             userDefaults.removeObject(forKey: activeModelKey)
         }
-        
+
         // Try to delete model files from disk
         deleteModelFiles(for: model)
     }
-    
+
     func deleteAllModels() {
         // Clear all models
         downloadedModels.removeAll()
         saveDownloadedModels()
-        
+
         // Clear active model
         activeModel = nil
+        activeAIModel = nil
         userDefaults.removeObject(forKey: activeModelKey)
         
         // Delete all model files
         for aiModel in AIModelsRegistry.shared.allModels {
-            deleteModelFiles(for: aiModel.configuration)
+            if let configuration = aiModel.mlxConfiguration {
+                deleteModelFiles(for: configuration)
+            }
         }
     }
     
+    // MARK: - Source-aware API (DEV-597)
+    // These operate on `AIModel` and dispatch on `ModelSource`, so callers no
+    // longer need to handle MLX `ModelConfiguration` directly. Sources that are
+    // not downloaded on-demand (e.g. Apple Foundation Models) are treated as
+    // always-ready and their download/delete operations become no-ops.
+
+    /// Whether the model is ready to use (downloaded for MLX, always-on for system models).
+    func isReady(_ model: AIModel) -> Bool {
+        switch model.source {
+        case .mlx(let configuration):
+            return downloadedModels.contains(configuration.name)
+        case .appleFoundation:
+            return true
+        }
+    }
+
+    /// Whether this is the currently active model.
+    func isActive(_ model: AIModel) -> Bool {
+        activeAIModel?.id == model.id
+    }
+
+    /// Whether an MLX download is currently in progress for this model.
+    func isDownloading(_ model: AIModel) -> Bool {
+        guard case .mlx(let configuration) = model.source else { return false }
+        return downloadingModels.contains(configuration.name)
+    }
+
+    /// Current download progress (`0...1`) for this model, if any.
+    func downloadProgress(for model: AIModel) -> Double {
+        guard case .mlx(let configuration) = model.source else { return 0 }
+        return downloadProgress[configuration.name] ?? 0
+    }
+
+    /// Marks the given model as active, persisting the selection.
+    func setActive(_ model: AIModel) {
+        switch model.source {
+        case .mlx(let configuration):
+            setActiveModel(configuration)
+        case .appleFoundation:
+            activeModel = nil
+            activeAIModel = model
+            userDefaults.set(model.id, forKey: activeModelKey)
+        }
+    }
+
+    /// Downloads the model if its source requires it; a no-op otherwise.
+    func download(_ model: AIModel, progressHandler: @escaping (Progress) -> Void) async throws {
+        switch model.source {
+        case .mlx(let configuration):
+            try await downloadModel(configuration, progressHandler: progressHandler)
+        case .appleFoundation:
+            return
+        }
+    }
+
+    /// Deletes the model's local files if its source has any; a no-op otherwise.
+    func delete(_ model: AIModel) {
+        switch model.source {
+        case .mlx(let configuration):
+            deleteModel(configuration)
+        case .appleFoundation:
+            return
+        }
+    }
+
     private func deleteModelFiles(for model: ModelConfiguration) {
         let fileManager = FileManager.default
 

--- a/Eris./Models/ModelSource.swift
+++ b/Eris./Models/ModelSource.swift
@@ -1,0 +1,24 @@
+//
+//  ModelSource.swift
+//  Eris.
+//
+//  Introduced in DEV-597 to decouple the domain from MLX.
+//
+
+import Foundation
+import MLXLMCommon
+
+/// Where an `AIModel` runs and how it is provisioned.
+///
+/// Discriminated union that lets a second inference backend (Apple
+/// Foundation Models, see DEV-598) coexist with MLX without leaking
+/// MLX-specific types (`ModelConfiguration`) across the whole domain.
+enum ModelSource {
+    /// On-device MLX model downloaded from Hugging Face. Carries its
+    /// `ModelConfiguration` (repo id, tokenizer, etc.).
+    case mlx(ModelConfiguration)
+
+    /// Apple's system on-device model (Foundation Models). No download and
+    /// no RAM management — the model already lives in the OS. (DEV-598)
+    case appleFoundation
+}

--- a/Eris./Views/Chat/ChatView.swift
+++ b/Eris./Views/Chat/ChatView.swift
@@ -7,12 +7,11 @@
 
 import SwiftUI
 import SwiftData
-import MLXLMCommon
 
 
 struct ChatView: View {
     @Environment(\.modelContext) private var modelContext
-    @StateObject private var llmEvaluator = LLMEvaluator()
+    @StateObject private var engine = ChatEngineRunner()
     @StateObject private var modelManager = ModelManager.shared
     @StateObject private var scrollManager = ChatScrollManager()
     @FocusState private var isInputFocused: Bool
@@ -35,7 +34,7 @@ struct ChatView: View {
                 ScrollView {
                         VStack(spacing: 16) {
                         // Empty state
-                        if thread.sortedMessages.isEmpty && !llmEvaluator.running {
+                        if thread.sortedMessages.isEmpty && !engine.running {
                             EmptyChatView()
                                 .padding(.top, 100)
                         }
@@ -51,8 +50,8 @@ struct ChatView: View {
                         }
                         
                         // Typing indicator
-                        if llmEvaluator.running {
-                            TypingIndicator(text: llmEvaluator.output)
+                        if engine.running {
+                            TypingIndicator(text: engine.output)
                                 .transition(.scale.combined(with: .opacity))
                         }
                         
@@ -96,17 +95,17 @@ struct ChatView: View {
                         scrollManager.handleNewMessage()
                     }
                 }
-                .onChange(of: llmEvaluator.running) { _, newValue in
+                .onChange(of: engine.running) { _, newValue in
                     if newValue {
                         scrollManager.handleTypingStarted()
                     }
                 }
-                .onChange(of: llmEvaluator.output) { _, _ in
+                .onChange(of: engine.output) { _, _ in
                     scrollManager.handleContentUpdate()
                 }
-                .onChange(of: llmEvaluator.tokensGenerated) { _, newTokenCount in
+                .onChange(of: engine.tokensGenerated) { _, newTokenCount in
                     // Check if we're generating a code block
-                    let codeBlockStarts = llmEvaluator.output.components(separatedBy: "```").count - 1
+                    let codeBlockStarts = engine.output.components(separatedBy: "```").count - 1
                     let isGeneratingCode = codeBlockStarts % 2 == 1
                     
                     // Haptic feedback only if we're scrolled to bottom and NOT generating code
@@ -159,14 +158,14 @@ struct ChatView: View {
             VStack(spacing: 0) {
                 ChatInputView(
                     text: $inputText,
-                    isGenerating: llmEvaluator.running,
-                    isLoadingModel: llmEvaluator.isLoadingModel,
+                    isGenerating: engine.running,
+                    isLoadingModel: engine.isLoadingModel,
                     onSend: {
                         HapticManager.shared.messageSent()
                         sendMessage()
                     },
                     onStop: {
-                        llmEvaluator.stopGeneration()
+                        engine.stop()
                     }
                 )
                 .focused($isInputFocused)
@@ -195,11 +194,11 @@ struct ChatView: View {
         .toolbar {
             if #available(iOS 26.0, *) {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    if let activeModel = modelManager.activeModel {
+                    if let activeModel = modelManager.activeAIModel {
                         HStack(spacing: 6) {
                             Image(systemName: "cpu")
                                 .font(.system(size: 14, weight: .medium))
-                            Text(formatModelName(activeModel))
+                            Text(activeModel.displayName)
                                 .font(.system(size: 14, weight: .medium))
                             Image(systemName: "chevron.down")
                                 .font(.system(size: 10, weight: .semibold))
@@ -217,7 +216,7 @@ struct ChatView: View {
                 .sharedBackgroundVisibility(.hidden)
             } else {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    if let activeModel = modelManager.activeModel {
+                    if let activeModel = modelManager.activeAIModel {
                         Button(action: {
                             HapticManager.shared.selection()
                             showModelPicker.toggle()
@@ -225,7 +224,7 @@ struct ChatView: View {
                             HStack(spacing: 6) {
                                 Image(systemName: "cpu")
                                     .font(.system(size: 14, weight: .medium))
-                                Text(formatModelName(activeModel))
+                                Text(activeModel.displayName)
                                     .font(.system(size: 14, weight: .medium))
                                 Image(systemName: "chevron.down")
                                     .font(.system(size: 10, weight: .semibold))
@@ -268,8 +267,8 @@ struct ChatView: View {
         }
         .sheet(isPresented: $showModelPicker) {
             NavigationStack {
-                ModelPickerView(selectedModel: modelManager.activeModel) { model in
-                    modelManager.setActiveModel(model)
+                ModelPickerView(selectedModel: modelManager.activeAIModel) { aiModel in
+                    modelManager.setActive(aiModel)
                     showModelPicker = false
                 }
                 .navigationTitle("Select Model")
@@ -291,7 +290,7 @@ struct ChatView: View {
         guard !inputText.isEmpty else { return }
         
         // Check if model is selected
-        guard modelManager.activeModel != nil else {
+        guard modelManager.activeAIModel != nil else {
             showNoModelAlert = true
             return
         }
@@ -345,7 +344,7 @@ struct ChatView: View {
             Be helpful, concise, and privacy-conscious in your responses.
             """
             
-            let response = await llmEvaluator.generate(thread: thread, systemPrompt: systemPrompt)
+            let response = await engine.generate(thread: thread, systemPrompt: systemPrompt)
             
             // Add assistant message
             let assistantMessage = Message(content: response, role: .assistant)
@@ -371,15 +370,6 @@ struct ChatView: View {
         }
     }
     
-    private func formatModelName(_ model: MLXLMCommon.ModelConfiguration) -> String {
-        model.name
-            .replacingOccurrences(of: "mlx-community/", with: "")
-            .replacingOccurrences(of: "-", with: " ")
-            .replacingOccurrences(of: "Instruct", with: "")
-            .replacingOccurrences(of: "4bit", with: "")
-            .replacingOccurrences(of: "8bit", with: "")
-            .trimmingCharacters(in: .whitespaces)
-    }
 }
 
 // MARK: - Chat Components

--- a/Eris./Views/Components/ModelPickerView.swift
+++ b/Eris./Views/Components/ModelPickerView.swift
@@ -6,30 +6,29 @@
 //
 
 import SwiftUI
-import MLXLMCommon
 
 struct ModelPickerView: View {
     @StateObject private var modelManager = ModelManager.shared
-    let selectedModel: MLXLMCommon.ModelConfiguration?
-    let onSelect: (MLXLMCommon.ModelConfiguration) -> Void
-    
+    let selectedModel: AIModel?
+    let onSelect: (AIModel) -> Void
+
     private let registry = AIModelsRegistry.shared
-    
+
     var body: some View {
         List {
             ForEach(ModelCategory.allCases, id: \.self) { category in
                 let downloadedModelsInCategory = registry.modelsForCategory(category)
-                    .filter { modelManager.isModelDownloaded($0.configuration) }
-                
+                    .filter { modelManager.isReady($0) }
+
                 if !downloadedModelsInCategory.isEmpty {
                     Section {
                         ForEach(downloadedModelsInCategory) { aiModel in
                             ModelPickerRow(
                                 aiModel: aiModel,
-                                isSelected: selectedModel?.name == aiModel.configuration.name,
+                                isSelected: selectedModel?.id == aiModel.id,
                                 onTap: {
                                     HapticManager.shared.selection()
-                                    onSelect(aiModel.configuration)
+                                    onSelect(aiModel)
                                 }
                             )
                         }

--- a/Eris./Views/Onboarding/OnboardingDownloadView.swift
+++ b/Eris./Views/Onboarding/OnboardingDownloadView.swift
@@ -6,12 +6,11 @@
 //
 
 import SwiftUI
-import MLXLMCommon
 
 struct OnboardingDownloadView: View {
     @Binding var showOnboarding: Bool
-    let selectedModel: ModelConfiguration
-    
+    let selectedModel: AIModel
+
     @StateObject private var modelManager = ModelManager.shared
     @StateObject private var networkMonitor = NetworkMonitor.shared
     @State private var downloadProgress: Double = 0.0
@@ -19,9 +18,9 @@ struct OnboardingDownloadView: View {
     @State private var errorMessage: String?
     @State private var showCompatibilityWarning = false
     @State private var showCellularWarning = false
-    
+
     private var selectedAIModel: AIModel? {
-        AIModelsRegistry.shared.modelByConfiguration(selectedModel)
+        selectedModel
     }
     
     enum DownloadState {
@@ -293,7 +292,7 @@ struct OnboardingDownloadView: View {
         
         Task {
             do {
-                try await modelManager.downloadModel(selectedModel) { progress in
+                try await modelManager.download(selectedModel) { progress in
                     Task { @MainActor in
                         self.downloadProgress = progress.fractionCompleted
                     }
@@ -323,7 +322,7 @@ struct OnboardingDownloadView: View {
     
     private func completeOnboarding() {
         // Set the downloaded model as active
-        modelManager.setActiveModel(selectedModel)
+        modelManager.setActive(selectedModel)
         
         // Mark onboarding as complete
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
@@ -337,7 +336,7 @@ struct OnboardingDownloadView: View {
     NavigationStack {
         OnboardingDownloadView(
             showOnboarding: .constant(true),
-            selectedModel: AIModelsRegistry.shared.defaultModel.configuration
+            selectedModel: AIModelsRegistry.shared.defaultModel
         )
     }
 }

--- a/Eris./Views/Onboarding/OnboardingModelSetupView.swift
+++ b/Eris./Views/Onboarding/OnboardingModelSetupView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import MLXLMCommon
 
 struct OnboardingModelSetupView: View {
     @Binding var showOnboarding: Bool
@@ -53,7 +52,7 @@ struct OnboardingModelSetupView: View {
                         ModelSelectionCard(
                             aiModel: aiModel,
                             isSelected: selectedAIModel?.id == aiModel.id,
-                            isDownloaded: modelManager.isModelDownloaded(aiModel.configuration),
+                            isDownloaded: modelManager.isReady(aiModel),
                             isRecommended: aiModel.id == getRecommendedModelForDevice().id && registry.compatibilityForModel(aiModel) == .recommended
                         ) {
                             HapticManager.shared.selection()
@@ -72,7 +71,7 @@ struct OnboardingModelSetupView: View {
                 NavigationLink(
                     destination: OnboardingDownloadView(
                         showOnboarding: $showOnboarding,
-                        selectedModel: selectedAIModel?.configuration ?? registry.defaultModel.configuration
+                        selectedModel: selectedAIModel ?? registry.defaultModel
                     )
                 ) {
                     Text("Download Model")

--- a/Eris./Views/Settings/DangerZoneView.swift
+++ b/Eris./Views/Settings/DangerZoneView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import SwiftData
-import MLXLMCommon
 
 struct DangerZoneView: View {
     @Environment(\.dismiss) private var dismiss
@@ -187,9 +186,9 @@ struct DangerZoneView: View {
         Task {
             // Clear all models from ModelManager
             for aiModel in AIModelsRegistry.shared.allModels {
-                modelManager.deleteModel(aiModel.configuration)
+                modelManager.delete(aiModel)
             }
-            
+
             // Try to clear cache directories
             clearModelCaches()
             
@@ -218,7 +217,7 @@ struct DangerZoneView: View {
                 
                 // Delete all models
                 for aiModel in AIModelsRegistry.shared.allModels {
-                    modelManager.deleteModel(aiModel.configuration)
+                    modelManager.delete(aiModel)
                 }
                 
                 // Clear all UserDefaults

--- a/Eris./Views/Settings/ModelManagementView.swift
+++ b/Eris./Views/Settings/ModelManagementView.swift
@@ -6,12 +6,11 @@
 //
 
 import SwiftUI
-import MLXLMCommon
 
 struct ModelManagementView: View {
     @StateObject private var modelManager = ModelManager.shared
     @StateObject private var networkMonitor = NetworkMonitor.shared
-    @State private var selectedModel: ModelConfiguration?
+    @State private var selectedModel: AIModel?
     @State private var showCompatibilityWarning = false
     @State private var modelToDownload: AIModel?
     @State private var showCellularWarning = false
@@ -93,15 +92,15 @@ struct ModelManagementView: View {
                             ForEach(registry.modelsForCategory(category)) { aiModel in
                                 ModelCard(
                                     aiModel: aiModel,
-                                    isSelected: modelManager.activeModel?.name == aiModel.configuration.name,
-                                    isDownloaded: modelManager.isModelDownloaded(aiModel.configuration),
-                                    isDownloading: modelManager.downloadingModels.contains(aiModel.configuration.name),
-                                    downloadProgress: modelManager.downloadProgress[aiModel.configuration.name] ?? 0.0,
+                                    isSelected: modelManager.isActive(aiModel),
+                                    isDownloaded: modelManager.isReady(aiModel),
+                                    isDownloading: modelManager.isDownloading(aiModel),
+                                    downloadProgress: modelManager.downloadProgress(for: aiModel),
                                     hasActiveDownload: !modelManager.downloadingModels.isEmpty,
                                     onSelect: {
                                         HapticManager.shared.selection()
-                                        if modelManager.isModelDownloaded(aiModel.configuration) {
-                                            modelManager.setActiveModel(aiModel.configuration)
+                                        if modelManager.isReady(aiModel) {
+                                            modelManager.setActive(aiModel)
                                         }
                                     },
                                     onDownload: {
@@ -124,13 +123,13 @@ struct ModelManagementView: View {
                                                 modelToDownload = aiModel
                                                 showCompatibilityWarning = true
                                             } else {
-                                                downloadModel(aiModel.configuration)
+                                                downloadModel(aiModel)
                                             }
                                         }
                                     },
                                     onDelete: {
                                         HapticManager.shared.warning()
-                                        deleteModel(aiModel.configuration)
+                                        deleteModel(aiModel)
                                     }
                                 )
                                 .disabled(DeviceUtils.isSimulator || !DeviceUtils.canRunMLX)
@@ -146,12 +145,12 @@ struct ModelManagementView: View {
         .navigationTitle("Model Management")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            selectedModel = modelManager.activeModel
+            selectedModel = modelManager.activeAIModel
         }
         .alert("Compatibility Warning", isPresented: $showCompatibilityWarning) {
             Button("Download Anyway", role: .destructive) {
                 if let aiModel = modelToDownload {
-                    downloadModel(aiModel.configuration)
+                    downloadModel(aiModel)
                 }
             }
             Button("Cancel", role: .cancel) {
@@ -177,10 +176,10 @@ struct ModelManagementView: View {
     }
     
     
-    private func downloadModel(_ model: ModelConfiguration) {
+    private func downloadModel(_ model: AIModel) {
         Task {
             do {
-                try await modelManager.downloadModel(model) { progress in
+                try await modelManager.download(model) { progress in
                     // Progress is already being tracked in ModelManager
                 }
                 
@@ -205,14 +204,15 @@ struct ModelManagementView: View {
         }
     }
     
-    private func deleteModel(_ model: ModelConfiguration) {
-        modelManager.deleteModel(model)
-        if modelManager.activeModel?.name == model.name {
-            // If deleting the active model, try to set another downloaded model as active
-            if let firstAvailableModel = registry.allModels.first(where: { 
-                $0.configuration.name != model.name && modelManager.isModelDownloaded($0.configuration) 
+    private func deleteModel(_ model: AIModel) {
+        let wasActive = modelManager.isActive(model)
+        modelManager.delete(model)
+        if wasActive {
+            // If deleting the active model, try to set another ready model as active
+            if let firstAvailableModel = registry.allModels.first(where: {
+                $0.id != model.id && modelManager.isReady($0)
             }) {
-                modelManager.setActiveModel(firstAvailableModel.configuration)
+                modelManager.setActive(firstAvailableModel)
             }
             // If no other models are downloaded, activeModel will be cleared automatically
         }


### PR DESCRIPTION
## Summary
Decouples the domain from MLX by introducing a `ModelSource` discriminated union and a `ChatEngine` inference abstraction, so a second backend (Apple Foundation Models) can be added without leaking `ModelConfiguration` across the app.

## Changes
- `ModelSource` (`.mlx` / `.appleFoundation`) is now the source of truth on `AIModel`; a convenience initializer keeps the registry declarations unchanged.
- `ChatEngine` protocol + `MLXEngine` (former `LLMEvaluator`, inference logic intact) + `ChatEngineRunner` (the observable the UI binds to). The runner selects the engine by the active model's source.
- `ModelManager` source-aware API (`isReady` / `setActive` / `download` / `delete`); sources that don't download are treated as ready with no-op download/delete.
- Migrated ChatView, ModelPickerView, ModelManagementView, DangerZoneView, onboarding and IntentUtils off `ModelConfiguration` onto `AIModel` — `ModelConfiguration` no longer appears in the UI layer.
- Fix: clear `activeAIModel` when deleting the active model.

## Notes
MLX behavior is unchanged and the project builds clean. Runtime smoke test on a physical device is pending (MLX requires Metal 3 hardware).

Closes DEV-597