### PR TITLE
feat: Add Apple Foundation Models as an on-device inference engine

### DIFF
--- a/Eris./Intents/GenerateTextIntent.swift
+++ b/Eris./Intents/GenerateTextIntent.swift
@@ -8,7 +8,6 @@
 import AppIntents
 import SwiftData
 import SwiftUI
-import MLXLMCommon
 
 @available(iOS 16.0, *)
 struct GenerateTextIntent: AppIntent {

--- a/Eris./Intents/IntentUtils.swift
+++ b/Eris./Intents/IntentUtils.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftData
-import MLXLMCommon
 
 enum IntentError: LocalizedError {
     case modelNotDownloaded(String)
@@ -33,17 +32,22 @@ struct IntentUtils {
     static let sharedRunner = ChatEngineRunner()
     
     /// Selects the appropriate model based on user input or defaults to active model
-    static func selectModel(requestedName: String?) -> Result<MLXLMCommon.ModelConfiguration, IntentError> {
+    static func selectModel(requestedName: String?) -> Result<AIModel, IntentError> {
         let modelManager = ModelManager.shared
-        
+
         if let requestedModel = requestedName, !requestedModel.isEmpty {
-            // Try to find the requested model
-            if let model = MLXLMCommon.ModelConfiguration.availableModels.first(where: { 
-                $0.name.lowercased().contains(requestedModel.lowercased()) ||
-                $0.name.replacingOccurrences(of: "mlx-community/", with: "").lowercased().contains(requestedModel.lowercased())
+            let needle = requestedModel.lowercased()
+            // Match by display name (e.g. "Apple", "Qwen") or MLX repo name.
+            if let model = AIModelsRegistry.shared.allModels.first(where: { model in
+                if model.displayName.lowercased().contains(needle) { return true }
+                if let name = model.mlxConfiguration?.name.lowercased() {
+                    return name.contains(needle)
+                        || name.replacingOccurrences(of: "mlx-community/", with: "").contains(needle)
+                }
+                return false
             }) {
-                // Check if model is downloaded
-                if modelManager.isModelDownloaded(model) {
+                // Check if model is ready to use (downloaded, or always-on for system models)
+                if modelManager.isReady(model) {
                     return .success(model)
                 } else {
                     return .failure(.modelNotDownloaded(requestedModel))
@@ -53,7 +57,7 @@ struct IntentUtils {
             }
         } else {
             // Use the active model
-            if let activeModel = modelManager.activeModel {
+            if let activeModel = modelManager.activeAIModel {
                 return .success(activeModel)
             } else {
                 return .failure(.noModelSelected)
@@ -80,36 +84,38 @@ struct IntentUtils {
     /// Generates a response using the specified model
     static func generateResponse(
         thread: Thread,
-        model: MLXLMCommon.ModelConfiguration,
+        model: AIModel,
         systemPrompt: String
     ) async -> String {
         let modelManager = ModelManager.shared
-        
+
         // Temporarily set the active model if using a different one
-        let originalModel = modelManager.activeModel
-        if model != originalModel {
-            modelManager.setActiveModel(model)
+        let originalModel = modelManager.activeAIModel
+        if originalModel?.id != model.id {
+            modelManager.setActive(model)
         }
-        
+
         // Use the shared chat engine runner for better performance
         let response = await sharedRunner.generate(
             thread: thread,
             systemPrompt: systemPrompt
         )
-        
+
         // Restore original model if changed
-        if model != originalModel, let original = originalModel {
-            modelManager.setActiveModel(original)
+        if originalModel?.id != model.id, let original = originalModel {
+            modelManager.setActive(original)
         }
-        
+
         return response
     }
-    
-    /// Returns a list of downloaded model names for shortcuts
+
+    /// Returns a list of ready-to-use model names for shortcuts
     static func getAvailableModelNames() -> [String] {
         let modelManager = ModelManager.shared
-        return MLXLMCommon.ModelConfiguration.availableModels
-            .filter { modelManager.isModelDownloaded($0) }
-            .map { $0.name.replacingOccurrences(of: "mlx-community/", with: "") }
+        return AIModelsRegistry.shared.allModels
+            .filter { modelManager.isReady($0) }
+            .map { model in
+                model.mlxConfiguration?.name.replacingOccurrences(of: "mlx-community/", with: "") ?? model.displayName
+            }
     }
 }

--- a/Eris./Intents/QuickChatIntent.swift
+++ b/Eris./Intents/QuickChatIntent.swift
@@ -8,7 +8,6 @@
 import AppIntents
 import SwiftData
 import SwiftUI
-import MLXLMCommon
 
 @available(iOS 16.0, *)
 struct QuickChatIntent: AppIntent {

--- a/Eris./Intents/SummarizeTextIntent.swift
+++ b/Eris./Intents/SummarizeTextIntent.swift
@@ -8,7 +8,6 @@
 import AppIntents
 import SwiftData
 import SwiftUI
-import MLXLMCommon
 
 @available(iOS 16.0, *)
 struct SummarizeTextIntent: AppIntent {

--- a/Eris./Intents/TranslateTextIntent.swift
+++ b/Eris./Intents/TranslateTextIntent.swift
@@ -8,7 +8,6 @@
 import AppIntents
 import SwiftData
 import SwiftUI
-import MLXLMCommon
 
 @available(iOS 16.0, *)
 struct TranslateTextIntent: AppIntent {

--- a/Eris./Models/AIModels.swift
+++ b/Eris./Models/AIModels.swift
@@ -145,14 +145,6 @@ struct AIModel: Identifiable {
         if case .appleFoundation = source { return true }
         return false
     }
-
-    var fullName: String {
-        mlxConfiguration?.name ?? displayName
-    }
-
-    var shortName: String {
-        displayName
-    }
 }
 
 // MARK: - AI Models Registry
@@ -452,22 +444,6 @@ class AIModelsRegistry {
     /// Returns only legacy models
     var legacyModels: [AIModel] {
         allModels.filter { $0.isLegacy }
-    }
-}
-
-// MARK: - Extensions for backward compatibility
-extension ModelConfiguration {
-    static var availableModels: [ModelConfiguration] {
-        AIModelsRegistry.shared.allModels.compactMap { $0.mlxConfiguration }
-    }
-
-    static var defaultModel: ModelConfiguration {
-        let defaultAIModel = AIModelsRegistry.shared.defaultModel
-        return defaultAIModel.mlxConfiguration ?? ModelConfiguration(id: defaultAIModel.id)
-    }
-
-    static func getModelByName(_ name: String) -> ModelConfiguration? {
-        AIModelsRegistry.shared.modelByName(name)?.mlxConfiguration
     }
 }
 

--- a/Eris./Models/AIModels.swift
+++ b/Eris./Models/AIModels.swift
@@ -139,6 +139,13 @@ struct AIModel: Identifiable {
         return nil
     }
 
+    /// `true` for models provisioned and managed by the OS (no download, no
+    /// RAM management) — currently only Apple Foundation Models.
+    var isSystemManaged: Bool {
+        if case .appleFoundation = source { return true }
+        return false
+    }
+
     var fullName: String {
         mlxConfiguration?.name ?? displayName
     }
@@ -301,14 +308,38 @@ class AIModelsRegistry {
         )
     ]
 
+    // MARK: - System Models (DEV-598)
+
+    /// The Apple Foundation Models entry. Defined as a value always; its
+    /// visibility is gated on runtime availability via `systemModels`.
+    static let appleFoundationModel = AIModel(
+        id: "apple_foundation",
+        source: .appleFoundation,
+        category: .general,
+        displayName: "Apple Intelligence",
+        description: "Apple's built-in on-device model. No download required.",
+        estimatedRAMUsage: 0,
+        minimumChipRequired: .a17Pro,
+        parameterCount: "Built-in",
+        quantization: "System"
+    )
+
+    /// System-managed models that are currently available on this device.
+    private var systemModels: [AIModel] {
+        AppleIntelligenceAvailability.current.isUsable ? [Self.appleFoundationModel] : []
+    }
+
     // MARK: - Public API
+
+    /// All models offered on this device: the bundled MLX catalog plus any
+    /// currently available system-managed models (e.g. Apple Intelligence).
     var allModels: [AIModel] {
-        models
+        systemModels + models
     }
 
     /// Returns models sorted by priority (non-legacy first, then by RAM usage)
     var sortedModels: [AIModel] {
-        models.sorted { m1, m2 in
+        allModels.sorted { m1, m2 in
             if m1.isLegacy != m2.isLegacy {
                 return !m1.isLegacy // Non-legacy first
             }
@@ -317,7 +348,7 @@ class AIModelsRegistry {
     }
 
     var categorizedModels: [ModelCategory: [AIModel]] {
-        let grouped = Dictionary(grouping: models, by: { $0.category })
+        let grouped = Dictionary(grouping: allModels, by: { $0.category })
         return grouped.mapValues { models in
             models.sorted { m1, m2 in
                 if m1.isLegacy != m2.isLegacy {
@@ -342,11 +373,17 @@ class AIModelsRegistry {
     }
 
     func modelById(_ id: String) -> AIModel? {
-        models.first { $0.id == id }
+        allModels.first { $0.id == id }
     }
 
     // MARK: - Compatibility
     func compatibilityForModel(_ model: AIModel) -> ModelCompatibility {
+        // System-managed models (Apple Intelligence) only appear when the OS
+        // reports them available, so they are always a good fit by definition.
+        if model.isSystemManaged {
+            return .recommended
+        }
+
         let chipFamily = DeviceUtils.chipFamily
         let deviceRAM = DeviceUtils.estimatedRAM
 
@@ -378,7 +415,7 @@ class AIModelsRegistry {
     }
 
     func recommendedModelsForDevice() -> [AIModel] {
-        models.filter { model in
+        allModels.filter { model in
             let compatibility = compatibilityForModel(model)
             return compatibility == .recommended || compatibility == .compatible
         }.sorted { model1, model2 in
@@ -399,7 +436,7 @@ class AIModelsRegistry {
     }
 
     func modelsForCategory(_ category: ModelCategory) -> [AIModel] {
-        models.filter { $0.category == category }.sorted { m1, m2 in
+        allModels.filter { $0.category == category }.sorted { m1, m2 in
             if m1.isLegacy != m2.isLegacy {
                 return !m1.isLegacy
             }
@@ -409,12 +446,12 @@ class AIModelsRegistry {
 
     /// Returns only non-legacy models
     var currentModels: [AIModel] {
-        models.filter { !$0.isLegacy }
+        allModels.filter { !$0.isLegacy }
     }
 
     /// Returns only legacy models
     var legacyModels: [AIModel] {
-        models.filter { $0.isLegacy }
+        allModels.filter { $0.isLegacy }
     }
 }
 

--- a/Eris./Models/Engines/ChatEngineRunner.swift
+++ b/Eris./Models/Engines/ChatEngineRunner.swift
@@ -20,16 +20,23 @@ final class ChatEngineRunner: ObservableObject, ChatEngineDelegate {
     // Concrete engines are cached so each keeps its own load state across
     // messages (the MLX engine caches the loaded `ModelContainer`).
     private lazy var mlxEngine = MLXEngine()
+    private var foundationEngine: ChatEngine?
     private var currentEngine: ChatEngine?
 
-    /// Resolves the engine for a given source. DEV-598 will return a
-    /// `FoundationModelsEngine` for `.appleFoundation`.
+    /// Resolves the engine for a given source.
     private func engine(for source: ModelSource) -> ChatEngine {
         switch source {
         case .mlx:
             return mlxEngine
         case .appleFoundation:
-            // Placeholder until DEV-598 wires up Apple Foundation Models.
+            if #available(iOS 26.0, *) {
+                if let foundationEngine { return foundationEngine }
+                let engine = FoundationModelsEngine()
+                foundationEngine = engine
+                return engine
+            }
+            // Unreachable in practice: the Apple model is never offered below
+            // iOS 26, but the switch must stay exhaustive.
             return mlxEngine
         }
     }

--- a/Eris./Models/Engines/FoundationModelsEngine.swift
+++ b/Eris./Models/Engines/FoundationModelsEngine.swift
@@ -66,6 +66,9 @@ final class FoundationModelsEngine: ChatEngine {
         let promptText = messages.last?.content ?? ""
         let history = Array(messages.dropLast())
 
+        // Nothing to send (no user turn) — avoid a pointless model call.
+        guard !promptText.isEmpty else { return "" }
+
         let session = LanguageModelSession(
             transcript: Self.buildTranscript(systemPrompt: systemPrompt, history: history)
         )

--- a/Eris./Models/Engines/FoundationModelsEngine.swift
+++ b/Eris./Models/Engines/FoundationModelsEngine.swift
@@ -1,0 +1,148 @@
+//
+//  FoundationModelsEngine.swift
+//  Eris.
+//
+//  Apple Foundation Models backed `ChatEngine` (DEV-598). Uses the system
+//  on-device model that powers Apple Intelligence — no download and no RAM
+//  management. Available on iOS 26+ with Apple Intelligence enabled.
+//
+
+import Foundation
+import FoundationModels
+
+/// Apple Intelligence availability, queryable from code that is not itself
+/// gated behind `@available(iOS 26, *)`. Wraps `SystemLanguageModel.availability`
+/// and adds an explicit case for running on an OS older than iOS 26.
+enum AppleIntelligenceAvailability: Equatable {
+    case available
+    case appleIntelligenceNotEnabled
+    case deviceNotEligible
+    case modelNotReady
+    case unsupportedOS
+    case unknown
+
+    static var current: AppleIntelligenceAvailability {
+        guard #available(iOS 26.0, *) else { return .unsupportedOS }
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return .available
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return .appleIntelligenceNotEnabled
+        case .unavailable(.deviceNotEligible):
+            return .deviceNotEligible
+        case .unavailable(.modelNotReady):
+            return .modelNotReady
+        case .unavailable:
+            return .unknown
+        }
+    }
+
+    /// `true` only when the model is ready to serve requests.
+    var isUsable: Bool { self == .available }
+}
+
+@available(iOS 26.0, *)
+@MainActor
+final class FoundationModelsEngine: ChatEngine {
+    private var isCancelled = false
+
+    func cancel() {
+        isCancelled = true
+    }
+
+    func generate(thread: Thread, systemPrompt: String, delegate: ChatEngineDelegate) async -> String {
+        isCancelled = false
+        // The system model is always resident — there is no loading phase.
+        delegate.chatEngine(self, didChangeLoadingState: false)
+
+        guard SystemLanguageModel.default.isAvailable else {
+            let message = Self.unavailableMessage(for: SystemLanguageModel.default.availability)
+            delegate.chatEngine(self, didProduceOutput: message, tokenCount: 0)
+            return message
+        }
+
+        // The latest message is the new user turn; everything before it is history.
+        let messages = thread.sortedMessages
+        let promptText = messages.last?.content ?? ""
+        let history = Array(messages.dropLast())
+
+        let session = LanguageModelSession(
+            transcript: Self.buildTranscript(systemPrompt: systemPrompt, history: history)
+        )
+
+        var output = ""
+        var tokens = 0
+        do {
+            let stream = session.streamResponse(to: promptText)
+            for try await snapshot in stream {
+                if isCancelled { break }
+                output = snapshot.content
+                tokens += 1
+                delegate.chatEngine(self, didProduceOutput: output, tokenCount: tokens)
+            }
+        } catch {
+            output = Self.friendlyError(error)
+            delegate.chatEngine(self, didProduceOutput: output, tokenCount: tokens)
+            print("❌ FoundationModels generation error: \(error)")
+        }
+
+        return output
+    }
+
+    // MARK: - Helpers
+
+    /// Rebuilds the conversation as a `Transcript` so the system model has the
+    /// full multi-turn context for each (stateless) generation call.
+    private static func buildTranscript(systemPrompt: String, history: [Message]) -> Transcript {
+        var entries: [Transcript.Entry] = [
+            .instructions(
+                Transcript.Instructions(
+                    segments: [textSegment(systemPrompt)],
+                    toolDefinitions: []
+                )
+            )
+        ]
+
+        for message in history {
+            switch message.role {
+            case .user, .system:
+                entries.append(.prompt(Transcript.Prompt(segments: [textSegment(message.content)])))
+            case .assistant:
+                entries.append(.response(Transcript.Response(assetIDs: [], segments: [textSegment(message.content)])))
+            }
+        }
+
+        return Transcript(entries: entries)
+    }
+
+    private static func textSegment(_ content: String) -> Transcript.Segment {
+        .text(Transcript.TextSegment(id: UUID().uuidString, content: content))
+    }
+
+    private static func friendlyError(_ error: Error) -> String {
+        if let generationError = error as? LanguageModelSession.GenerationError {
+            switch generationError {
+            case .exceededContextWindowSize:
+                return "Error: This conversation is too long for Apple Intelligence. Start a new chat to continue."
+            default:
+                return "Error: \(error.localizedDescription)"
+            }
+        }
+        return "Error: \(error.localizedDescription)"
+    }
+
+    private static func unavailableMessage(for availability: SystemLanguageModel.Availability) -> String {
+        switch availability {
+        case .available:
+            return "Apple Intelligence is currently unavailable."
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return "Apple Intelligence is turned off. Enable it in Settings to use this model."
+        case .unavailable(.deviceNotEligible):
+            return "This device doesn't support Apple Intelligence."
+        case .unavailable(.modelNotReady):
+            return "Apple Intelligence is still preparing. Please try again in a moment."
+        case .unavailable:
+            return "Apple Intelligence is currently unavailable."
+        }
+    }
+}

--- a/Eris./Views/Onboarding/OnboardingModelSetupView.swift
+++ b/Eris./Views/Onboarding/OnboardingModelSetupView.swift
@@ -164,6 +164,7 @@ struct ModelSelectionCard: View {
     private let registry = AIModelsRegistry.shared
     
     var modelSize: String {
+        if aiModel.isSystemManaged { return "Built-in" }
         let sizeInGB = Double(aiModel.estimatedRAMUsage) / 1024.0
         return String(format: "%.1f GB", sizeInGB)
     }
@@ -232,18 +233,20 @@ struct ModelSelectionCard: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .lineLimit(2)
                         
-                        // Compatibility indicator
-                        let compatibility = registry.compatibilityForModel(aiModel)
-                        HStack(spacing: 4) {
-                            Image(systemName: compatibility.icon)
-                                .font(.caption)
-                                .foregroundColor(compatibility.color)
-                            Text(compatibility.description)
-                                .font(.caption)
-                                .foregroundColor(compatibility.color)
-                            Spacer()
+                        // Compatibility indicator (not shown for system-managed models)
+                        if !aiModel.isSystemManaged {
+                            let compatibility = registry.compatibilityForModel(aiModel)
+                            HStack(spacing: 4) {
+                                Image(systemName: compatibility.icon)
+                                    .font(.caption)
+                                    .foregroundColor(compatibility.color)
+                                Text(compatibility.description)
+                                    .font(.caption)
+                                    .foregroundColor(compatibility.color)
+                                Spacer()
+                            }
+                            .padding(.top, 2)
                         }
-                        .padding(.top, 2)
                     }
                     
                     Spacer()

--- a/Eris./Views/Onboarding/OnboardingModelSetupView.swift
+++ b/Eris./Views/Onboarding/OnboardingModelSetupView.swift
@@ -68,28 +68,51 @@ struct OnboardingModelSetupView: View {
             
             // Continue button
             if DeviceUtils.canRunMLX {
-                NavigationLink(
-                    destination: OnboardingDownloadView(
-                        showOnboarding: $showOnboarding,
-                        selectedModel: selectedAIModel ?? registry.defaultModel
-                    )
-                ) {
-                    Text("Download Model")
-                        .font(.headline)
-                        .foregroundColor(Color(UIColor.systemBackground))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 56)
-                        .background(selectedAIModel != nil ? Color(UIColor.label) : Color.gray)
-                        .cornerRadius(16)
-                }
-                .disabled(selectedAIModel == nil)
-                .simultaneousGesture(TapGesture().onEnded { _ in
-                    if selectedAIModel != nil {
+                if selectedAIModel?.isSystemManaged == true {
+                    // System-managed models (Apple Intelligence) need no download:
+                    // activate them and finish onboarding directly.
+                    Button {
                         HapticManager.shared.buttonTap()
+                        if let model = selectedAIModel {
+                            modelManager.setActive(model)
+                        }
+                        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                        showOnboarding = false
+                    } label: {
+                        Text("Continue")
+                            .font(.headline)
+                            .foregroundColor(Color(UIColor.systemBackground))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(Color(UIColor.label))
+                            .cornerRadius(16)
                     }
-                })
-                .padding(.horizontal, 20)
-                .padding(.bottom, 30)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 30)
+                } else {
+                    NavigationLink(
+                        destination: OnboardingDownloadView(
+                            showOnboarding: $showOnboarding,
+                            selectedModel: selectedAIModel ?? registry.defaultModel
+                        )
+                    ) {
+                        Text("Download Model")
+                            .font(.headline)
+                            .foregroundColor(Color(UIColor.systemBackground))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .background(selectedAIModel != nil ? Color(UIColor.label) : Color.gray)
+                            .cornerRadius(16)
+                    }
+                    .disabled(selectedAIModel == nil)
+                    .simultaneousGesture(TapGesture().onEnded { _ in
+                        if selectedAIModel != nil {
+                            HapticManager.shared.buttonTap()
+                        }
+                    })
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 30)
+                }
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/Eris./Views/Settings/ModelManagementView.swift
+++ b/Eris./Views/Settings/ModelManagementView.swift
@@ -67,7 +67,14 @@ struct ModelManagementView: View {
                         .padding(.horizontal, 20)
                         .padding(.bottom, 20)
                 }
-                
+
+                // Apple Intelligence status: prompt the user to enable it when eligible (DEV-598)
+                if AppleIntelligenceAvailability.current == .appleIntelligenceNotEnabled {
+                    AppleIntelligenceBanner()
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 20)
+                }
+
                 // Models list by category
                 VStack(spacing: 20) {
                     ForEach(ModelCategory.allCases, id: \.self) { category in
@@ -252,6 +259,42 @@ struct DeviceCompatibilityWarning: View {
     }
 }
 
+struct AppleIntelligenceBanner: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles")
+                    .foregroundColor(.primary)
+                Text("Apple Intelligence")
+                    .font(.headline)
+                Spacer()
+            }
+
+            Text("Turn on Apple Intelligence in Settings to use Apple's built-in on-device model — no download required.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                Text("Open Settings")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Color(UIColor.label))
+                    .foregroundColor(Color(UIColor.systemBackground))
+                    .cornerRadius(12)
+            }
+        }
+        .padding()
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+}
+
 struct ModelCard: View {
     let aiModel: AIModel
     let isSelected: Bool
@@ -323,49 +366,63 @@ struct ModelCard: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .lineLimit(2)
-                        
-                        // Compatibility indicator
-                        let compatibility = registry.compatibilityForModel(aiModel)
-                        HStack(spacing: 4) {
-                            Image(systemName: compatibility.icon)
-                                .font(.caption)
-                                .foregroundColor(compatibility.color)
-                            Text(compatibility.description)
-                                .font(.caption)
-                                .foregroundColor(compatibility.color)
-                            Spacer()
-                        }
-                        .padding(.top, 2)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        HStack(spacing: 12) {
-                            // Storage size
+
+                        if aiModel.isSystemManaged {
+                            // System-managed models (Apple Intelligence): no download, no RAM management.
                             HStack(spacing: 4) {
-                                Image(systemName: "internaldrive")
+                                Image(systemName: "sparkles")
                                     .font(.caption)
-                                Text(modelSize)
+                                Text("Built-in • Managed by iOS")
                                     .font(.caption)
+                                Spacer()
                             }
-                            
-                            // RAM usage
+                            .foregroundColor(.secondary)
+                            .padding(.top, 2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
+                            // Compatibility indicator
+                            let compatibility = registry.compatibilityForModel(aiModel)
                             HStack(spacing: 4) {
-                                Image(systemName: "memorychip")
+                                Image(systemName: compatibility.icon)
                                     .font(.caption)
-                                Text("~\(String(format: "%.1f", Double(aiModel.estimatedRAMUsage) / 1024.0))GB RAM")
+                                    .foregroundColor(compatibility.color)
+                                Text(compatibility.description)
                                     .font(.caption)
+                                    .foregroundColor(compatibility.color)
+                                Spacer()
                             }
-                        }
-                        .foregroundColor(.secondary)
-                        
-                        // Warning for large models on iPhone
-                        if aiModel.parameterCount.contains("7B") && UIDevice.current.userInterfaceIdiom == .phone {
-                            HStack(spacing: 4) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .font(.caption2)
-                                Text("May run slowly on iPhone")
-                                    .font(.caption2)
+                            .padding(.top, 2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                            HStack(spacing: 12) {
+                                // Storage size
+                                HStack(spacing: 4) {
+                                    Image(systemName: "internaldrive")
+                                        .font(.caption)
+                                    Text(modelSize)
+                                        .font(.caption)
+                                }
+
+                                // RAM usage
+                                HStack(spacing: 4) {
+                                    Image(systemName: "memorychip")
+                                        .font(.caption)
+                                    Text("~\(String(format: "%.1f", Double(aiModel.estimatedRAMUsage) / 1024.0))GB RAM")
+                                        .font(.caption)
+                                }
                             }
-                            .foregroundColor(.orange)
+                            .foregroundColor(.secondary)
+
+                            // Warning for large models on iPhone
+                            if aiModel.parameterCount.contains("7B") && UIDevice.current.userInterfaceIdiom == .phone {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .font(.caption2)
+                                    Text("May run slowly on iPhone")
+                                        .font(.caption2)
+                                }
+                                .foregroundColor(.orange)
+                            }
                         }
                     }
                     
@@ -389,8 +446,10 @@ struct ModelCard: View {
                                         Label("Set as Active", systemImage: "checkmark.circle")
                                     }
                                 }
-                                Button(role: .destructive, action: onDelete) {
-                                    Label("Delete Model", systemImage: "trash")
+                                if !aiModel.isSystemManaged {
+                                    Button(role: .destructive, action: onDelete) {
+                                        Label("Delete Model", systemImage: "trash")
+                                    }
                                 }
                             } label: {
                                 Image(systemName: "ellipsis.circle")

--- a/Eris./Views/Settings/ModelManagementView.swift
+++ b/Eris./Views/Settings/ModelManagementView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ModelManagementView: View {
     @StateObject private var modelManager = ModelManager.shared
     @StateObject private var networkMonitor = NetworkMonitor.shared
-    @State private var selectedModel: AIModel?
     @State private var showCompatibilityWarning = false
     @State private var modelToDownload: AIModel?
     @State private var showCellularWarning = false
@@ -139,7 +138,7 @@ struct ModelManagementView: View {
                                         deleteModel(aiModel)
                                     }
                                 )
-                                .disabled(DeviceUtils.isSimulator || !DeviceUtils.canRunMLX)
+                                .disabled(!aiModel.isSystemManaged && (DeviceUtils.isSimulator || !DeviceUtils.canRunMLX))
                                 .padding(.horizontal, 20)
                             }
                         }
@@ -151,9 +150,6 @@ struct ModelManagementView: View {
         .background(Color(UIColor.systemGroupedBackground))
         .navigationTitle("Model Management")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            selectedModel = modelManager.activeAIModel
-        }
         .alert("Compatibility Warning", isPresented: $showCompatibilityWarning) {
             Button("Download Anyway", role: .destructive) {
                 if let aiModel = modelToDownload {


### PR DESCRIPTION
## Summary
Adds Apple Intelligence (iOS 26+) as a second on-device `ChatEngine`, using the source abstraction from DEV-597.

> **Stacked on #9 (DEV-597).** Review/merge that one first — GitHub will retarget this PR to `main` automatically once #9 merges.

## Changes
- `FoundationModelsEngine: ChatEngine` wrapping `LanguageModelSession`: multi-turn `Transcript` seeding from the thread, streaming via `ResponseStream` snapshots, cancellation, and availability/context error handling.
- `AppleIntelligenceAvailability` helper over `SystemLanguageModel.availability`, usable from non-`@available(iOS 26)` code.
- Registry "Apple Intelligence" entry (`source: .appleFoundation`), shown only when the system reports it available.
- `.appleFoundation` routed through the `ChatEngineRunner` engine factory.
- `IntentUtils` migrated to `AIModel` so App Intents can use the Apple model.
- UI treats it as built-in (no size/RAM/delete) and prompts to enable Apple Intelligence in Settings when eligible but turned off.

## Notes
Verified against the installed FoundationModels SDK; the project builds clean. Runtime test pending on a device with Apple Intelligence enabled.

Closes DEV-598